### PR TITLE
Add security settings page and dynamic organization info display

### DIFF
--- a/Client/Pages/Salary/SalaryManagement.razor
+++ b/Client/Pages/Salary/SalaryManagement.razor
@@ -2,6 +2,11 @@
 @layout EmptyLayout
 @using Safir.Client.Pages.Salary.Tabs
 @using Safir.Shared.Models.Salary
+@using Safir.Client.Services
+@using Safir.Shared.Constants
+@using Microsoft.AspNetCore.Components.Authorization
+@inject ClientAppSettingsService AppSettingsService
+@inject AuthenticationStateProvider AuthenticationStateProvider
 
 @* ══════════════════════════════════════════════════════════
    Toast — نمایش پیام‌های عملیاتی
@@ -25,17 +30,17 @@
         <div class="pay2-brand">
             <div class="pay2-brand-icon">P2</div>
             <div>
-                <div class="pay2-brand-name">مستر کارکت</div>
+                <div class="pay2-brand-name">@(_companyName ?? "سیستم حقوق")</div>
                 <div class="pay2-brand-version">نسخه PAY2 v6.0</div>
             </div>
         </div>
 
         @* کارت دوره فعال *@
         <div class="pay2-period-card">
-            <div class="pay2-period-label">دوره فعال</div>
+            <div class="pay2-period-label">سال مالی</div>
             <div class="pay2-period-row">
-                <div class="pay2-period-value">۱۴۰۴/۰۱</div>
-                <div class="pay2-period-badge">باز</div>
+                <div class="pay2-period-value">@(_fiscalYear?.ToString() ?? "---")</div>
+                <div class="pay2-period-badge">فعال</div>
             </div>
         </div>
 
@@ -111,9 +116,9 @@
 
         @* فوتر سایدبار *@
         <div class="pay2-sidebar-footer">
-            <div class="pay2-user-avatar">مد</div>
+            <div class="pay2-user-avatar">@_userInitials</div>
             <div>
-                <div class="pay2-user-name">مدیر سیستم</div>
+                <div class="pay2-user-name">@(_currentUsername ?? "کاربر")</div>
                 <div class="pay2-user-role">کارگاه مرکزی</div>
             </div>
         </div>
@@ -325,6 +330,11 @@
     private string ToastMessage = string.Empty;
     private int _toastVersion = 0;
 
+    private string? _companyName;
+    private short? _fiscalYear;
+    private string? _currentUsername;
+    private string _userInitials = "کا";
+
     // ──────────────────────────────────────────
     // داده‌های placeholder داشبورد
     // (بعداً از API واقعی جایگزین می‌شود)
@@ -337,6 +347,34 @@
       new("سارا رضایی",  "ADV_HES / T-1050", "۲۰,۰۰۰,۰۰۰"),
       new("محمد کریمی",  "ADV_HES / T-1050", "۵,۰۰۰,۰۰۰"),
     };
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var sazman = await AppSettingsService.GetSettingsAsync();
+            _companyName = sazman?.NAME;
+            _fiscalYear = sazman?.YEA;
+        }
+        catch { }
+
+        try
+        {
+            var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+            var user = authState.User;
+            if (user.Identity?.IsAuthenticated == true)
+            {
+                _currentUsername = user.FindFirst(BaseknowClaimTypes.UUSER)?.Value
+                                   ?? user.Identity.Name
+                                   ?? "کاربر";
+                if (!string.IsNullOrEmpty(_currentUsername) && _currentUsername.Length >= 2)
+                    _userInitials = _currentUsername.Substring(0, 2);
+                else if (!string.IsNullOrEmpty(_currentUsername))
+                    _userInitials = _currentUsername;
+            }
+        }
+        catch { }
+    }
 
     // ══════════════════════════════════════════
     // ناوبری تب‌ها

--- a/Client/Pages/Salary/SalaryManagement.razor
+++ b/Client/Pages/Salary/SalaryManagement.razor
@@ -5,8 +5,11 @@
 @using Safir.Client.Services
 @using Safir.Shared.Constants
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.Extensions.Logging
 @inject ClientAppSettingsService AppSettingsService
 @inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ISnackbar Snackbar
+@inject ILogger<SalaryManagement> Logger
 
 @* ══════════════════════════════════════════════════════════
    Toast — نمایش پیام‌های عملیاتی
@@ -356,7 +359,11 @@
             _companyName = sazman?.NAME;
             _fiscalYear = sazman?.YEA;
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load SAZMAN settings in SalaryManagement.");
+            Snackbar.Add("خطا در بارگذاری اطلاعات سازمان.", Severity.Warning);
+        }
 
         try
         {
@@ -367,13 +374,15 @@
                 _currentUsername = user.FindFirst(BaseknowClaimTypes.UUSER)?.Value
                                    ?? user.Identity.Name
                                    ?? "کاربر";
-                if (!string.IsNullOrEmpty(_currentUsername) && _currentUsername.Length >= 2)
-                    _userInitials = _currentUsername.Substring(0, 2);
-                else if (!string.IsNullOrEmpty(_currentUsername))
-                    _userInitials = _currentUsername;
+                _userInitials = !string.IsNullOrEmpty(_currentUsername) && _currentUsername.Length >= 2
+                    ? _currentUsername[..2]
+                    : (_currentUsername ?? "کا");
             }
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load authentication state in SalaryManagement.");
+        }
     }
 
     // ══════════════════════════════════════════

--- a/Client/Pages/SecuritySettings.razor
+++ b/Client/Pages/SecuritySettings.razor
@@ -1,0 +1,158 @@
+@page "/settings/security"
+@using Safir.Client.Services
+@using Safir.Shared.Models
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
+
+@inject ClientAppSettingsService AppSettingsService
+@inject HttpClient HttpClient
+@inject ISnackbar Snackbar
+
+<PageTitle>تنظیمات امنیتی | سفیر</PageTitle>
+
+<MudContainer MaxWidth="MaxWidth.Medium" Class="my-4">
+    <MudText Typo="Typo.h5" Class="mb-4">تنظیمات سرور و پایگاه داده</MudText>
+
+    @if (_isLoading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" Class="mb-4" />
+    }
+
+    <MudGrid>
+        <MudItem xs="12" md="6">
+            <MudPaper Elevation="2" Class="pa-4 rounded-lg">
+                <MudText Typo="Typo.h6" Class="mb-3">اطلاعات اتصال پایگاه داده</MudText>
+                <MudDivider Class="mb-3" />
+
+                <MudStack Spacing="2">
+                    <div>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">نام سرور</MudText>
+                        <MudText Typo="Typo.body1" Style="font-family: monospace; direction: ltr; text-align: left;">
+                            @(_dbInfo?.DatabaseServer ?? "---")
+                        </MudText>
+                    </div>
+                    <MudDivider />
+                    <div>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">نام دیتابیس</MudText>
+                        <MudText Typo="Typo.body1" Style="font-family: monospace; direction: ltr; text-align: left;">
+                            @(_dbInfo?.DatabaseName ?? "---")
+                        </MudText>
+                    </div>
+                    <MudDivider />
+                    <div>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">محیط اجرا</MudText>
+                        <MudText Typo="Typo.body1">@(_dbInfo?.EnvironmentName ?? "---")</MudText>
+                    </div>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12" md="6">
+            <MudPaper Elevation="2" Class="pa-4 rounded-lg">
+                <MudText Typo="Typo.h6" Class="mb-3">اطلاعات سازمان (SAZMAN)</MudText>
+                <MudDivider Class="mb-3" />
+
+                <MudStack Spacing="2">
+                    <div>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">نام شرکت</MudText>
+                        <MudText Typo="Typo.body1">@(_sazman?.NAME ?? "---")</MudText>
+                    </div>
+                    <MudDivider />
+                    <div>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">سال مالی</MudText>
+                        <MudText Typo="Typo.body1">@(_sazman?.YEA?.ToString() ?? "---")</MudText>
+                    </div>
+                    <MudDivider />
+                    <div>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">حداکثر بدهکاری</MudText>
+                        <MudText Typo="Typo.body1">@(_sazman?.BEDEHKAR?.ToString("N0") ?? "---")</MudText>
+                    </div>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+
+        <MudItem xs="12">
+            <MudPaper Elevation="1" Class="pa-4 rounded-lg">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                    <div>
+                        <MudText Typo="Typo.subtitle1">بارگذاری مجدد تنظیمات از دیتابیس</MudText>
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">
+                            اطلاعات سازمان را از دیتابیس جاری مجدداً بارگذاری می‌کند.
+                        </MudText>
+                    </div>
+                    <MudButton Variant="Variant.Filled"
+                               Color="Color.Primary"
+                               StartIcon="@Icons.Material.Filled.Refresh"
+                               OnClick="RefreshSettingsAsync"
+                               Disabled="_isRefreshing">
+                        @if (_isRefreshing)
+                        {
+                            <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="me-2" />
+                        }
+                        بارگذاری مجدد
+                    </MudButton>
+                </MudStack>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+</MudContainer>
+
+@code {
+    private bool _isLoading = true;
+    private bool _isRefreshing = false;
+    private SAZMAN? _sazman;
+    private DebugInfoDto? _dbInfo;
+
+    private class DebugInfoDto
+    {
+        public string? EnvironmentName { get; set; }
+        public string? DatabaseServer { get; set; }
+        public string? DatabaseName { get; set; }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDataAsync();
+    }
+
+    private async Task LoadDataAsync()
+    {
+        _isLoading = true;
+        try
+        {
+            _sazman = await AppSettingsService.GetSettingsAsync();
+            _dbInfo = await HttpClient.GetFromJsonAsync<DebugInfoDto>("api/settings/debug-info");
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"خطا در بارگذاری اطلاعات: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task RefreshSettingsAsync()
+    {
+        _isRefreshing = true;
+        StateHasChanged();
+        try
+        {
+            var refreshed = await AppSettingsService.RefreshFromServerAsync();
+            _sazman = refreshed;
+            if (refreshed != null)
+                Snackbar.Add("تنظیمات با موفقیت از دیتابیس بارگذاری شد.", Severity.Success);
+            else
+                Snackbar.Add("بارگذاری انجام شد اما اطلاعاتی دریافت نشد.", Severity.Warning);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"خطا در بارگذاری مجدد: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _isRefreshing = false;
+        }
+    }
+}

--- a/Client/Services/ClientAppSettingsService.cs
+++ b/Client/Services/ClientAppSettingsService.cs
@@ -71,9 +71,32 @@ namespace Safir.Client.Services
         public async Task<int?> Get_BEDEHKAR_Async()
         {
             var settings = await GetSettingsAsync();
-            return settings?.BEDEHKAR; // نام فیلد را مطابق مدل SAZMAN تنظیم کنید
+            return settings?.BEDEHKAR;
         }
 
-        // سایر متدهای Get... برای فیلدهای دیگر
+        public void ResetCache()
+        {
+            _cachedSettings = null;
+            _isLoaded = false;
+        }
+
+        public async Task<SAZMAN?> RefreshFromServerAsync()
+        {
+            ResetCache();
+            try
+            {
+                var response = await _httpClient.PostAsync("api/appsettings/refresh", null);
+                if (response.IsSuccessStatusCode)
+                {
+                    _cachedSettings = await response.Content.ReadFromJsonAsync<SAZMAN>();
+                    _isLoaded = _cachedSettings != null;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Client: Failed to refresh application settings from API.");
+            }
+            return _cachedSettings;
+        }
     }
 }

--- a/Client/Services/ClientAppSettingsService.cs
+++ b/Client/Services/ClientAppSettingsService.cs
@@ -76,27 +76,45 @@ namespace Safir.Client.Services
 
         public void ResetCache()
         {
-            _cachedSettings = null;
-            _isLoaded = false;
+            _initLock.Wait();
+            try
+            {
+                _cachedSettings = null;
+                _isLoaded = false;
+            }
+            finally
+            {
+                _initLock.Release();
+            }
         }
 
         public async Task<SAZMAN?> RefreshFromServerAsync()
         {
-            ResetCache();
+            SAZMAN? previous = _cachedSettings;
             try
             {
                 var response = await _httpClient.PostAsync("api/appsettings/refresh", null);
                 if (response.IsSuccessStatusCode)
                 {
-                    _cachedSettings = await response.Content.ReadFromJsonAsync<SAZMAN>();
-                    _isLoaded = _cachedSettings != null;
+                    var refreshed = await response.Content.ReadFromJsonAsync<SAZMAN>();
+                    await _initLock.WaitAsync();
+                    try
+                    {
+                        _cachedSettings = refreshed;
+                        _isLoaded = refreshed != null;
+                    }
+                    finally
+                    {
+                        _initLock.Release();
+                    }
+                    return _cachedSettings;
                 }
             }
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Client: Failed to refresh application settings from API.");
             }
-            return _cachedSettings;
+            return previous;
         }
     }
 }

--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -3,6 +3,7 @@
 @using Safir.Client.Services
 @using Safir.Shared.Interfaces;
 @using Safir.Shared.Models
+@implements IDisposable
 @inject NavigationManager NavigationManager
 @inject IAuthService AuthService
 @inject MudBlazor.IDialogService DialogService
@@ -18,22 +19,21 @@
         صفحه اصلی
     </MudNavLink>
 
-    @if (_sazmanSettings != null)
-    {
-        <div class="px-4 py-2" style="border-bottom: 1px solid var(--mud-palette-divider);">
-            @if (!string.IsNullOrEmpty(_sazmanSettings.NAME))
-            {
-                <MudText Typo="Typo.subtitle2" Style="font-weight:700;">@_sazmanSettings.NAME</MudText>
-            }
-            @if (_sazmanSettings.YEA.HasValue)
-            {
-                <MudText Typo="Typo.caption" Color="Color.Secondary">سال مالی: @_sazmanSettings.YEA</MudText>
-            }
-        </div>
-    }
-
     <AuthorizeView>
         <Authorized>
+            @if (_sazmanSettings != null)
+            {
+                <div class="px-4 py-2" style="border-bottom: 1px solid var(--mud-palette-divider);">
+                    @if (!string.IsNullOrEmpty(_sazmanSettings.NAME))
+                    {
+                        <MudText Typo="Typo.subtitle2" Style="font-weight:700;">@_sazmanSettings.NAME</MudText>
+                    }
+                    @if (_sazmanSettings.YEA.HasValue)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">سال مالی: @_sazmanSettings.YEA</MudText>
+                    }
+                </div>
+            }
             <!-- ثبت سفارش -->
             @if (_isCustomerSelected)
             {

--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -2,6 +2,7 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Safir.Client.Services
 @using Safir.Shared.Interfaces;
+@using Safir.Shared.Models
 @inject NavigationManager NavigationManager
 @inject IAuthService AuthService
 @inject MudBlazor.IDialogService DialogService
@@ -9,12 +10,27 @@
 @inject ISnackbar Snackbar
 @inject IJSRuntime JSRuntime
 @inject UserStateApiService UserStateApiService
+@inject ClientAppSettingsService AppSettingsService
 
 <MudNavMenu>
     <!-- صفحه اصلی -->
     <MudNavLink Href="/" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">
         صفحه اصلی
     </MudNavLink>
+
+    @if (_sazmanSettings != null)
+    {
+        <div class="px-4 py-2" style="border-bottom: 1px solid var(--mud-palette-divider);">
+            @if (!string.IsNullOrEmpty(_sazmanSettings.NAME))
+            {
+                <MudText Typo="Typo.subtitle2" Style="font-weight:700;">@_sazmanSettings.NAME</MudText>
+            }
+            @if (_sazmanSettings.YEA.HasValue)
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary">سال مالی: @_sazmanSettings.YEA</MudText>
+            }
+        </div>
+    }
 
     <AuthorizeView>
         <Authorized>
@@ -108,12 +124,14 @@
 @code {
     private bool collapseNavMenu = true;
 
-    private string appVersion = "1.0.0"; // می‌توانید این مقدار را مطابق نسخه پروژه در csproj یا منبع دیگر تنظیم کنید
+    private string appVersion = "1.0.0";
 
     private bool _isCustomerSelected = false;
 
+    private SAZMAN? _sazmanSettings;
+
     // --- Lifecycle and Event Handling ---
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         // Set initial state based on current cart status
         _isCustomerSelected = CartService.CurrentCustomer != null;
@@ -125,13 +143,16 @@
             var version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
             if (version != null)
             {
-                // به‌عنوان مثال: "1.0.0.0"
                 appVersion = version.ToString();
             }
         }
         catch { }
 
-        base.OnInitialized();
+        try
+        {
+            _sazmanSettings = await AppSettingsService.GetSettingsAsync();
+        }
+        catch { }
     }
     private void OnCartChanged()
     {

--- a/Server/Controllers/AppSettingsController.cs
+++ b/Server/Controllers/AppSettingsController.cs
@@ -1,19 +1,22 @@
 ﻿namespace Safir.Server.Controllers
 {
-    // File: Server/Controllers/AppSettingsController.cs (یا اکشن در SettingsController)
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Safir.Shared.Interfaces;
     using Safir.Shared.Models;
     using System.Threading.Tasks;
 
-    [Route("api/appsettings")] // آدرس API
+    [Route("api/appsettings")]
     [ApiController]
-    [Authorize] // <<-- دسترسی فقط برای کاربران لاگین کرده
+    [Authorize]
     public class AppSettingsController : ControllerBase
     {
         private readonly IAppSettingsService _appSettingsService;
         private readonly ILogger<AppSettingsController> _logger;
+
+        // cooldown: حداقل ۳۰ ثانیه بین هر refresh
+        private static DateTimeOffset _lastRefresh = DateTimeOffset.MinValue;
+        private static readonly TimeSpan _refreshCooldown = TimeSpan.FromSeconds(30);
 
         public AppSettingsController(IAppSettingsService appSettingsService, ILogger<AppSettingsController> logger)
         {
@@ -31,15 +34,24 @@
                 _logger.LogWarning("SAZMAN settings are not available.");
                 return NotFound("Application settings could not be loaded.");
             }
-            _logger.LogInformation("Returning SAZMAN settings via API.");
             return Ok(settings);
         }
 
         [HttpPost("refresh")]
         public async Task<ActionResult<SAZMAN>> RefreshAppSettings()
         {
-            _logger.LogInformation("Cache reset requested for AppSettingsService");
+            var now = DateTimeOffset.UtcNow;
+            var remaining = _refreshCooldown - (now - _lastRefresh);
+            if (remaining > TimeSpan.Zero)
+            {
+                return StatusCode(429, $"لطفاً {(int)remaining.TotalSeconds} ثانیه دیگر صبر کنید.");
+            }
+
+            _logger.LogInformation("Cache reset requested for AppSettingsService by user {User}",
+                User.Identity?.Name);
             _appSettingsService.ResetCache();
+            _lastRefresh = now;
+
             var settings = await _appSettingsService.GetSazmanSettingsAsync();
             if (settings == null)
             {

--- a/Server/Controllers/AppSettingsController.cs
+++ b/Server/Controllers/AppSettingsController.cs
@@ -21,7 +21,7 @@
             _logger = logger;
         }
 
-        [HttpGet] // متد GET
+        [HttpGet]
         public async Task<ActionResult<SAZMAN>> GetAppSettings()
         {
             _logger.LogInformation("API request received for GetAppSettings");
@@ -29,11 +29,22 @@
             if (settings == null)
             {
                 _logger.LogWarning("SAZMAN settings are not available.");
-                // می‌توانید 500 برگردانید یا یک شیء خالی با کد 200
                 return NotFound("Application settings could not be loaded.");
-                // یا return Ok(new SAZMAN());
             }
             _logger.LogInformation("Returning SAZMAN settings via API.");
+            return Ok(settings);
+        }
+
+        [HttpPost("refresh")]
+        public async Task<ActionResult<SAZMAN>> RefreshAppSettings()
+        {
+            _logger.LogInformation("Cache reset requested for AppSettingsService");
+            _appSettingsService.ResetCache();
+            var settings = await _appSettingsService.GetSazmanSettingsAsync();
+            if (settings == null)
+            {
+                return NotFound("Application settings could not be loaded after refresh.");
+            }
             return Ok(settings);
         }
     }

--- a/Server/Controllers/SettingsController.cs
+++ b/Server/Controllers/SettingsController.cs
@@ -1,10 +1,11 @@
 ﻿// In Safir.Server/Controllers/SettingsController.cs (New File)
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Data.SqlClient;
 
 [Route("api/[controller]")]
 [ApiController]
-// [Authorize(Roles = "Admin")] // <<< IMPORTANT: Add authorization for production!
+[Authorize]
 public class SettingsController : ControllerBase
 {
     private readonly IConfiguration _configuration;

--- a/Server/Services/AppSettingsService.cs
+++ b/Server/Services/AppSettingsService.cs
@@ -98,10 +98,18 @@ namespace Safir.Server.Services
 
         public void ResetCache()
         {
-            _cachedSazmanSettings = null;
-            _cachedBedehkarKol = null;
-            _isInitialized = false;
-            _logger.LogInformation("AppSettingsService cache has been reset.");
+            _initLock.Wait();
+            try
+            {
+                _cachedSazmanSettings = null;
+                _cachedBedehkarKol = null;
+                _isInitialized = false;
+                _logger.LogInformation("AppSettingsService cache has been reset.");
+            }
+            finally
+            {
+                _initLock.Release();
+            }
         }
     }
 }

--- a/Server/Services/AppSettingsService.cs
+++ b/Server/Services/AppSettingsService.cs
@@ -95,5 +95,13 @@ namespace Safir.Server.Services
             }
             return _cachedBedehkarKol;
         }
+
+        public void ResetCache()
+        {
+            _cachedSazmanSettings = null;
+            _cachedBedehkarKol = null;
+            _isInitialized = false;
+            _logger.LogInformation("AppSettingsService cache has been reset.");
+        }
     }
 }

--- a/Shared/Interfaces/IAppSettingsService.cs
+++ b/Shared/Interfaces/IAppSettingsService.cs
@@ -9,10 +9,8 @@ namespace Safir.Shared.Interfaces
 {
     public interface IAppSettingsService
     {
-        // متد جدید برای دریافت کل تنظیمات سازمان
         Task<SAZMAN?> GetSazmanSettingsAsync();
-
         Task<int?> GetDefaultBedehkarKolAsync();
-        // Add other global settings if needed
+        void ResetCache();
     }
 }


### PR DESCRIPTION
## Summary
This PR introduces a new Security Settings page and enhances the application to dynamically display organization information (company name, fiscal year) throughout the UI. It also adds cache refresh functionality for application settings.

## Key Changes

### New Features
- **SecuritySettings.razor page**: New `/settings/security` page displaying:
  - Database connection information (server, database name, environment)
  - Organization settings (SAZMAN) including company name, fiscal year, and maximum debt
  - Refresh button to reload settings from the database with rate limiting (30-second cooldown)

- **Dynamic organization display**: 
  - SalaryManagement.razor now displays actual company name and fiscal year instead of hardcoded values
  - NavMenu.razor displays organization name and fiscal year in the navigation sidebar
  - Current username and user initials now displayed dynamically in SalaryManagement

### Backend Enhancements
- **AppSettingsController**: Added `POST /api/appsettings/refresh` endpoint with rate limiting to prevent abuse
- **AppSettingsService (Server)**: Added `ResetCache()` method to clear cached settings
- **IAppSettingsService**: Updated interface to include `ResetCache()` method

### Client-Side Improvements
- **ClientAppSettingsService**: 
  - Added `ResetCache()` method for clearing local cache
  - Added `RefreshFromServerAsync()` method to fetch fresh settings from the server
  - Improved thread-safe cache management

- **SalaryManagement.razor**: 
  - Loads SAZMAN settings and authentication state on initialization
  - Displays company name, fiscal year, and current user information dynamically
  - Added proper error handling and logging

- **NavMenu.razor**: 
  - Displays organization information in the navigation menu
  - Implements IDisposable for proper resource cleanup

### Security & Implementation Details
- All new endpoints require `[Authorize]` attribute
- Rate limiting implemented on refresh endpoint (30-second cooldown) to prevent abuse
- Proper error handling with user-friendly Farsi error messages
- Thread-safe cache operations using SemaphoreSlim locks
- Logging added for debugging and monitoring

## Testing Recommendations
- Verify SecuritySettings page loads correctly with proper authorization
- Test refresh functionality with rate limiting (should block requests within 30 seconds)
- Confirm organization info displays correctly in SalaryManagement and NavMenu
- Validate error handling when settings are unavailable

https://claude.ai/code/session_01BDxm6RibRRu1ubkKx977td