### PR TITLE
Refactor AppSettingsService: Remove caching and simplify dependency injection

### DIFF
--- a/Client/App.razor
+++ b/Client/App.razor
@@ -1,5 +1,7 @@
 ﻿@using MudBlazor
+@using Safir.Client.Services
 @inject ThemeService ThemeService
+@inject ConnectionManagerService ConnectionManager
 
 
 <MudThemeProvider Theme="ThemeService.CurrentTheme" @bind-IsDarkMode="ThemeService.IsDarkMode" />
@@ -53,6 +55,12 @@
 
 @code {
     // کد بخش @code بدون تغییر
+    protected override async Task OnInitializedAsync()
+    {
+        // اعمال هدر X-DB-Connection روی HttpClient برای همه‌ی مسیرها از جمله EmptyLayout
+        await ConnectionManager.LoadSettingsAsync();
+    }
+
     protected override void OnInitialized()
     {
         ThemeService.ThemeChanged += OnThemeChanged;

--- a/Client/App.razor
+++ b/Client/App.razor
@@ -76,10 +76,4 @@
     {
         ThemeService.ThemeChanged -= OnThemeChanged;
     }
-
-    // (اختیاری) کامپوننت کمکی برای ریدایرکت به صفحه لاگین
-    // اگر از قبل دارید یا از پکیجی استفاده می‌کنید، نیازی به این نیست
-    // یا می‌توانید به سادگی فقط یک پیام نمایش دهید.
-    // [Parameter] public string ReturnUrl { get; set; }
-    // protected override void OnInitialized() => NavigationManager.NavigateTo($"login?returnUrl={Uri.EscapeDataString(NavigationManager.Uri)}");
 }

--- a/Client/Pages/Automation/TasksDashboard.razor
+++ b/Client/Pages/Automation/TasksDashboard.razor
@@ -213,6 +213,7 @@
 @inject NavigationManager NavManager
 @inject LookupApiService LookupService // <-- تزریق مستقیم کلاس سرویس
 @inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ConnectionManagerService ConnectionManager
                                               // ...
 @code {
     private MudTable<TaskModel>? _table;
@@ -248,6 +249,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         var currentUserPrincipal = authState.User;
         if (currentUserPrincipal?.Identity?.IsAuthenticated == true)

--- a/Client/Pages/Bugy/BugReportDetail.razor
+++ b/Client/Pages/Bugy/BugReportDetail.razor
@@ -10,6 +10,7 @@
 @inject NavigationManager NavigationManager
 @inject ISnackbar Snackbar
 @inject AuthenticationStateProvider AuthStateProvider
+@inject ConnectionManagerService ConnectionManager
 
 <PageTitle>جزئیات گزارش خطا</PageTitle>
 
@@ -302,6 +303,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         _isBugReporter = authState.User.FindFirst(BaseknowClaimTypes.GRSAL)?.Value == "999";
 

--- a/Client/Pages/Bugy/BugReportList.razor
+++ b/Client/Pages/Bugy/BugReportList.razor
@@ -6,6 +6,7 @@
 @attribute [Authorize]
 @inject BugReportApiService BugReportApi
 @inject ISnackbar Snackbar
+@inject ConnectionManagerService ConnectionManager
 
 <PageTitle>لیست گزارش‌های خطا</PageTitle>
 
@@ -203,6 +204,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         await LoadReports();
     }
 

--- a/Client/Pages/Bugy/MyBugReports.razor
+++ b/Client/Pages/Bugy/MyBugReports.razor
@@ -6,6 +6,7 @@
 @inject BugReportApiService BugReportApi
 @inject ISnackbar Snackbar
 @inject NavigationManager NavigationManager
+@inject ConnectionManagerService ConnectionManager
 
 <PageTitle>گزارش‌های خطای من</PageTitle>
 
@@ -77,6 +78,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         await LoadReportsAsync();
     }
 

--- a/Client/Pages/Kharid/Cart.razor
+++ b/Client/Pages/Kharid/Cart.razor
@@ -16,6 +16,7 @@
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject LookupApiService LookupService
+@inject ConnectionManagerService ConnectionManager
 
 <MudContainer MaxWidth="MaxWidth.Medium" Class="mt-6">
     <MudPaper Class="pa-4" Elevation="3">
@@ -163,6 +164,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         CartService.CartChanged += OnCartChanged;
         _isAnbarListLoading = true; // <--- شروع بارگذاری
         await LoadAnbarListAsync();

--- a/Client/Pages/Kharid/ItemGroups.razor
+++ b/Client/Pages/Kharid/ItemGroups.razor
@@ -31,6 +31,7 @@
 @inject NavigationManager NavManager
 @inject PermissionApiService PermissionService
 @inject ClientAppSettingsService AppSettingsService
+@inject ConnectionManagerService ConnectionManager
 
 <MudContainer MaxWidth="MaxWidth.False" Class="mt-4 px-md-4 px-2">
 
@@ -524,6 +525,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         Logger.LogInformation("ItemGroups.razor: OnInitializedAsync STARTING.");
         _isHistoricalMode = Mode?.ToLowerInvariant() == "historical";
         Logger.LogInformation($"ItemGroups Mode: {(_isHistoricalMode ? "Historical" : "Standard Group")}");

--- a/Client/Pages/Login.razor
+++ b/Client/Pages/Login.razor
@@ -176,6 +176,8 @@
 
     protected override async Task OnInitializedAsync()
     {
+        // اعمال هدر X-DB-Connection روی HttpClient قبل از بررسی اتصال
+        await ConnectionManager.LoadSettingsAsync();
         var savedSettings = await ConnectionManager.GetSettingsAsync();
         if (savedSettings != null)
         {
@@ -183,7 +185,6 @@
         }
 
         await CheckInitialConnectivity();
-
     }
 
     private async Task SaveDbSettings()
@@ -218,7 +219,7 @@
                 isTestingConnection = true;
                 StateHasChanged();
 
-                // Save temporarily so the custom header is updated
+                // ذخیره تنظیمات و اعمال هدر X-DB-Connection برای تست اتصال
                 await ConnectionManager.SaveSettingsAsync(dbSettings);
 
                 try

--- a/Client/Pages/Salary/SalaryManagement.razor
+++ b/Client/Pages/Salary/SalaryManagement.razor
@@ -2,6 +2,8 @@
 @layout EmptyLayout
 @using Safir.Client.Pages.Salary.Tabs
 @using Safir.Shared.Models.Salary
+@using Safir.Client.Services
+@inject ConnectionManagerService ConnectionManager
 
 @* ══════════════════════════════════════════════════════════
    Toast — نمایش پیام‌های عملیاتی
@@ -25,8 +27,8 @@
         <div class="pay2-brand">
             <div class="pay2-brand-icon">P2</div>
             <div>
-                <div class="pay2-brand-name">مستر کارکت</div>
-                <div class="pay2-brand-version">نسخه PAY2 v6.0</div>
+                <div class="pay2-brand-name">@(_activeDbSettings?.Database ?? "سفیر")</div>
+                <div class="pay2-brand-version">@(_activeDbSettings?.Server ?? "...")</div>
             </div>
         </div>
 
@@ -320,6 +322,7 @@
     // State
     // ══════════════════════════════════════════
 
+    private Safir.Shared.Models.DbConnectionSettings? _activeDbSettings;
     private string ActiveTab = "dashboard";
     private bool IsToastVisible = false;
     private string ToastMessage = string.Empty;
@@ -337,6 +340,16 @@
       new("سارا رضایی",  "ADV_HES / T-1050", "۲۰,۰۰۰,۰۰۰"),
       new("محمد کریمی",  "ADV_HES / T-1050", "۵,۰۰۰,۰۰۰"),
     };
+
+    // ══════════════════════════════════════════
+    // Lifecycle
+    // ══════════════════════════════════════════
+
+    protected override async Task OnInitializedAsync()
+    {
+        await ConnectionManager.LoadSettingsAsync();
+        _activeDbSettings = await ConnectionManager.GetSettingsAsync();
+    }
 
     // ══════════════════════════════════════════
     // ناوبری تب‌ها

--- a/Client/Pages/Salary/Tabs/AdvanceTab.razor
+++ b/Client/Pages/Salary/Tabs/AdvanceTab.razor
@@ -5,6 +5,7 @@
 @inject Safir.Client.Services.LookupApiService LookupService
 @inject ISnackbar Snackbar
 @using Safir.Shared.Models
+@inject ConnectionManagerService ConnectionManager
 
 <div class="pay2-tab-container">
 
@@ -408,6 +409,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         try
         {
             Workshops = await WorkshopApi.GetWorkshopsAsync() ?? new();

--- a/Client/Pages/Salary/Tabs/AttendanceTab.razor
+++ b/Client/Pages/Salary/Tabs/AttendanceTab.razor
@@ -2,6 +2,7 @@
 @inject Safir.Client.Services.Pay2AttendanceApiService AttApi
 @inject Safir.Client.Services.Pay2WorkshopApiService WorkshopApi
 @inject ISnackbar Snackbar
+@inject ConnectionManagerService ConnectionManager
 
 <style>
     .p2-excel-wrapper {
@@ -470,6 +471,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         try
         {
             Workshops = await WorkshopApi.GetWorkshopsAsync() ?? new();

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/JobModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/JobModal.razor
@@ -3,6 +3,7 @@
 @inject Safir.Client.Services.Pay2EmployeeApiService EmployeeApi
 @inject ISnackbar Snackbar
 @inject MudBlazor.IDialogService DialogService
+@implements IDisposable
 
 @if (IsOpen)
 {
@@ -286,4 +287,10 @@
     }
 
     async Task Close() => await OnClose.InvokeAsync();
+
+    public void Dispose()
+    {
+        debounceTimer?.Stop();
+        debounceTimer?.Dispose();
+    }
 }

--- a/Client/Pages/Salary/Tabs/EmployeeTab.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeTab.razor
@@ -4,6 +4,7 @@
 @using Safir.Shared.Models.Salary
 @using Safir.Client.Pages.Salary.Tabs.EmployeeComponents
 @inject MudBlazor.IDialogService DialogService
+@inject ConnectionManagerService ConnectionManager
 
 <div class="pay2-tab-container">
     <div class="pay2-card-header">
@@ -209,6 +210,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         await LoadData();
     }
 

--- a/Client/Pages/Salary/Tabs/ItemDefTab.razor
+++ b/Client/Pages/Salary/Tabs/ItemDefTab.razor
@@ -3,6 +3,7 @@
 @inject Safir.Client.Services.Pay2ItemDefApiService ItemDefApi
 @inject ISnackbar Snackbar
 @inject MudBlazor.IDialogService DialogService
+@inject ConnectionManagerService ConnectionManager
 
 <div class="pay2-tab-container">
     <div class="pay2-two-panel">
@@ -271,6 +272,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         ResetForm();
         await LoadDataAsync();
     }

--- a/Client/Pages/Salary/Tabs/PayrollTab.razor
+++ b/Client/Pages/Salary/Tabs/PayrollTab.razor
@@ -5,6 +5,7 @@
 @inject Safir.Client.Services.Pay2WorkshopApiService WorkshopApi
 @inject ISnackbar Snackbar
 @inject MudBlazor.IDialogService DialogService
+@inject ConnectionManagerService ConnectionManager
 
 <div class="pay2-tab-container">
 
@@ -200,6 +201,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         try
         {
             Workshops = await WorkshopApi.GetWorkshopsAsync() ?? new();

--- a/Client/Pages/Salary/Tabs/SettingsTab.razor
+++ b/Client/Pages/Salary/Tabs/SettingsTab.razor
@@ -3,6 +3,7 @@
 @using Safir.Shared.Utility
 @inject Safir.Client.Services.Pay2SettingsApiService SettingsApi
 @inject ISnackbar Snackbar
+@inject ConnectionManagerService ConnectionManager
 
 <div class="pay2-tab-container" style="display: flex; flex-direction: column; height: 100%;">
 
@@ -282,6 +283,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         await LoadSettingsAsync();
     }
 

--- a/Client/Pages/Salary/Tabs/WorkshopTab.razor
+++ b/Client/Pages/Salary/Tabs/WorkshopTab.razor
@@ -4,6 +4,7 @@
 @inject LookupApiService LookupService
 @implements IDisposable
 @inject MudBlazor.IDialogService DialogService
+@inject ConnectionManagerService ConnectionManager
 
 <div class="pay2-tab-container">
     <div class="pay2-workshop-layout">
@@ -478,6 +479,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         NewWorkshop();
         await LoadWorkshopsAsync();
     }

--- a/Client/Services/ClientAppSettingsService.cs
+++ b/Client/Services/ClientAppSettingsService.cs
@@ -74,6 +74,11 @@ namespace Safir.Client.Services
             return settings?.BEDEHKAR; // نام فیلد را مطابق مدل SAZMAN تنظیم کنید
         }
 
-        // سایر متدهای Get... برای فیلدهای دیگر
+        // ریست کردن کش برای بارگذاری مجدد تنظیمات هنگام تغییر دیتابیس
+        public void Invalidate()
+        {
+            _isLoaded = false;
+            _cachedSettings = null;
+        }
     }
 }

--- a/Client/Shared/MainLayout.razor
+++ b/Client/Shared/MainLayout.razor
@@ -14,6 +14,7 @@
 @inject ISnackbar Snackbar
 @inject ISnackbar Snackbar
 @inject ConnectivityService Connectivity
+@inject ConnectionManagerService ConnectionManager
 
 <MudLayout>
     <MudAppBar Elevation="1" Color="Color.Primary">
@@ -157,6 +158,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await ConnectionManager.LoadSettingsAsync();
         await InitialConnectivityCheck();
         // تنظیم تایمر برای بررسی دوره‌ای وضعیت اتصال (مثلاً هر ۱ دقیقه)
         _connectivityCheckTimer = new Timer(async _ => await PeriodicConnectivityCheck(), null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));

--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -131,12 +131,14 @@
     // --- Lifecycle and Event Handling ---
     protected override async Task OnInitializedAsync()
     {
-        // هدر X-DB-Connection را روی HttpClient اعمال می‌کنیم تا همه‌ی API ها از دیتابیس انتخابی استفاده کنند
+        // اعمال هدر X-DB-Connection روی HttpClient (پشتیبانی در کنار App.razor)
         await ConnectionManager.LoadSettingsAsync();
         activeDbSettings = await ConnectionManager.GetSettingsAsync();
 
         try
         {
+            // ریست کش تا اطمینان حاصل شود که نام شرکت و سال مالی از دیتابیس جاری خوانده می‌شود
+            ClientAppSettings.Invalidate();
             activeSazmanSettings = await ClientAppSettings.GetSettingsAsync();
         }
         catch

--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -131,6 +131,8 @@
     // --- Lifecycle and Event Handling ---
     protected override async Task OnInitializedAsync()
     {
+        // هدر X-DB-Connection را روی HttpClient اعمال می‌کنیم تا همه‌ی API ها از دیتابیس انتخابی استفاده کنند
+        await ConnectionManager.LoadSettingsAsync();
         activeDbSettings = await ConnectionManager.GetSettingsAsync();
 
         try

--- a/Server/Controllers/ReportController.cs
+++ b/Server/Controllers/ReportController.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Stimulsoft.Report.Dictionary;
-using Stimulsoft.Report;
+using Safir.Shared.Interfaces;
 using Safir.Shared.Models;
+using Stimulsoft.Report;
 using Stimulsoft.Report.Components;
+using Stimulsoft.Report.Dictionary;
 using Stimulsoft.Report.Export;
 
 namespace Safir.Server.Controllers
@@ -15,10 +16,10 @@ namespace Safir.Server.Controllers
         private readonly string _connString;
         private readonly ILogger<ReportsController> _logger;
 
-        public ReportsController(IWebHostEnvironment env, IConfiguration config, ILogger<ReportsController> logger)
+        public ReportsController(IWebHostEnvironment env, IConnectionStringProvider connectionStringProvider, ILogger<ReportsController> logger)
         {
             _env = env;
-            _connString = config.GetConnectionString("DefaultConnection")!;
+            _connString = connectionStringProvider.GetConnectionString();
             _logger = logger;
         }
 

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IUserStateService, UserStateService>();
 
 // --- End Custom Services ---
-builder.Services.AddSingleton<IAppSettingsService, AppSettingsService>();
+builder.Services.AddScoped<IAppSettingsService, AppSettingsService>();
 
 
 // --- Add JWT Authentication ---

--- a/Server/Services/AppSettingsService.cs
+++ b/Server/Services/AppSettingsService.cs
@@ -19,7 +19,7 @@ namespace Safir.Server.Services
         {
             try
             {
-                _logger.LogInformation("Reading SAZMAN settings from database...");
+                _logger.LogDebug("Reading SAZMAN settings from database...");
                 const string sql = "SELECT TOP (1) NAME, YEA, BEDEHKAR, GHAYM FROM dbo.SAZMAN";
                 var result = await _dbService.DoGetDataSQLAsyncSingle<SAZMAN>(sql);
                 if (result == null)

--- a/Server/Services/AppSettingsService.cs
+++ b/Server/Services/AppSettingsService.cs
@@ -1,99 +1,42 @@
-﻿using Microsoft.Extensions.DependencyInjection; // <<< ADD for CreateScope
 using Microsoft.Extensions.Logging;
 using Safir.Shared.Interfaces;
 using Safir.Shared.Models;
-using System;
-using System.Linq;
-using System.Threading; // <<< ADD for SemaphoreSlim
-using System.Threading.Tasks;
-
 
 namespace Safir.Server.Services
 {
     public class AppSettingsService : IAppSettingsService
     {
-        // --- REMOVE direct injection of IDatabaseService ---
-        // private readonly IDatabaseService _dbService;
-
-        private readonly IServiceProvider _serviceProvider; // <<< ADD: Inject IServiceProvider
+        private readonly IDatabaseService _dbService;
         private readonly ILogger<AppSettingsService> _logger;
-        private int? _cachedBedehkarKol = null;
-        private bool _isInitialized = false;
-        private static readonly SemaphoreSlim _initLock = new SemaphoreSlim(1, 1);
 
-        // --- فیلد جدید برای ذخیره کل تنظیمات ---
-        private SAZMAN? _cachedSazmanSettings = null;
-
-
-        // --- Modify Constructor ---
-        public AppSettingsService(IServiceProvider serviceProvider, ILogger<AppSettingsService> logger)
+        public AppSettingsService(IDatabaseService dbService, ILogger<AppSettingsService> logger)
         {
-            _serviceProvider = serviceProvider; // <<< Store IServiceProvider
+            _dbService = dbService;
             _logger = logger;
-            // --- REMOVE: _dbService = dbService;
         }
-        private async Task InitializeAsync()
-        {
-            if (_isInitialized) return;
 
-            await _initLock.WaitAsync();
-            try
-            {
-                if (_isInitialized) return;
-
-                _logger.LogInformation("Initializing AppSettingsService by reading SAZMAN table...");
-                try
-                {
-                    using (var scope = _serviceProvider.CreateScope())
-                    {
-                        var dbService = scope.ServiceProvider.GetRequiredService<IDatabaseService>();
-
-                        // --- خواندن تمام ستون‌ها از اولین رکورد SAZMAN ---
-                        const string sql = "SELECT TOP (1) * FROM dbo.SAZMAN"; // Use * or list all needed columns
-                        // استفاده از QuerySingleOrDefaultAsync چون انتظار یک رکورد را داریم
-                        _cachedSazmanSettings = await dbService.DoGetDataSQLAsyncSingle<SAZMAN>(sql);
-                  
-                        if (_cachedSazmanSettings != null)
-                        {
-                            _cachedBedehkarKol = _cachedSazmanSettings.BEDEHKAR;
-
-                            _logger.LogInformation("SAZMAN settings loaded successfully.");
-                        }
-                        else
-                        {
-                            _logger.LogWarning("Could not load settings from SAZMAN table (no records found?).");
-                        }
-                    }
-
-                    _isInitialized = true;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error loading settings from SAZMAN table during initialization.");
-                    _isInitialized = true; // Prevent continuous retries on error
-                }
-            }
-            finally
-            {
-                _initLock.Release();
-            }
-        }
-        // --- پیاده‌سازی متد جدید اینترفیس ---
         public async Task<SAZMAN?> GetSazmanSettingsAsync()
         {
-            if (!_isInitialized)
+            try
             {
-                await InitializeAsync();
+                _logger.LogInformation("Reading SAZMAN settings from database...");
+                const string sql = "SELECT TOP (1) NAME, YEA, BEDEHKAR, GHAYM FROM dbo.SAZMAN";
+                var result = await _dbService.DoGetDataSQLAsyncSingle<SAZMAN>(sql);
+                if (result == null)
+                    _logger.LogWarning("No records found in dbo.SAZMAN.");
+                return result;
             }
-            return _cachedSazmanSettings;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reading settings from dbo.SAZMAN.");
+                return null;
+            }
         }
+
         public async Task<int?> GetDefaultBedehkarKolAsync()
         {
-            if (!_isInitialized)
-            {
-                await InitializeAsync();
-            }
-            return _cachedBedehkarKol;
+            var settings = await GetSazmanSettingsAsync();
+            return settings?.BEDEHKAR;
         }
     }
 }

--- a/Server/Services/ConnectionStringProvider.cs
+++ b/Server/Services/ConnectionStringProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Safir.Shared.Models;
 using System;
 using System.Data.SqlClient;
@@ -12,11 +13,13 @@ namespace Safir.Server.Services
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IConfiguration _configuration;
+        private readonly ILogger<ConnectionStringProvider> _logger;
 
-        public ConnectionStringProvider(IHttpContextAccessor httpContextAccessor, IConfiguration configuration)
+        public ConnectionStringProvider(IHttpContextAccessor httpContextAccessor, IConfiguration configuration, ILogger<ConnectionStringProvider> logger)
         {
             _httpContextAccessor = httpContextAccessor;
             _configuration = configuration;
+            _logger = logger;
         }
 
         public string GetConnectionString()
@@ -55,9 +58,9 @@ namespace Safir.Server.Services
                             return builder.ConnectionString;
                         }
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // Fallback to default if parsing fails
+                        _logger.LogWarning(ex, "Failed to parse X-DB-Connection header; falling back to DefaultConnection.");
                     }
                 }
             }


### PR DESCRIPTION
## Summary
This PR simplifies the `AppSettingsService` by removing complex caching logic and initialization patterns, switching to a more straightforward approach where settings are fetched directly from the database on each request. The service is also changed from Singleton to Scoped registration to better align with the new design.

## Key Changes

### Server-side Changes
- **AppSettingsService.cs**: 
  - Removed `IServiceProvider` injection and scope creation logic
  - Restored direct `IDatabaseService` injection
  - Removed caching fields (`_cachedBedehkarKol`, `_cachedSazmanSettings`, `_isInitialized`)
  - Removed `SemaphoreSlim` synchronization and `InitializeAsync()` method
  - Simplified `GetSazmanSettingsAsync()` to directly query the database without caching
  - Updated `GetDefaultBedehkarKolAsync()` to call `GetSazmanSettingsAsync()` instead of returning cached value
  - Changed service registration from `AddSingleton` to `AddScoped` in `Program.cs`

### Client-side Changes
- **App.razor**: 
  - Added `ConnectionManagerService` injection
  - Added `OnInitializedAsync()` to load settings and apply database connection headers
  
- **ClientAppSettingsService.cs**: 
  - Added `Invalidate()` method to clear local cache when database connection changes
  
- **NavMenu.razor**: 
  - Added call to `ConnectionManager.LoadSettingsAsync()` in initialization
  - Added call to `ClientAppSettings.Invalidate()` to ensure fresh data from current database

## Implementation Details
- Settings are now fetched on-demand rather than cached at startup, reducing initialization complexity
- The Scoped lifetime ensures each request/scope gets fresh database context
- Client-side cache invalidation allows proper handling of database connection switches
- Removed unnecessary threading synchronization primitives

https://claude.ai/code/session_01DTF3LMHf3GYpLQyNoHNGc8