### PR TITLE
حقوق و دستمزد (PAY2): شش درخواست کاربری + موتور محاسبه v6.1

### DIFF
--- a/Client/Pages/Salary/Tabs/AttendanceTab.razor
+++ b/Client/Pages/Salary/Tabs/AttendanceTab.razor
@@ -404,9 +404,9 @@
                                 <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.DAYS_KHADAMAT_STR" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
                                 <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.DAYS_FOROSH_STR" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
 
-                                <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.OT_NORMAL_H_STR" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
-                                <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.OT_HOLIDAY_H_STR" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
-                                <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.OT_ADMIN_H_STR" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
+                                <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.OT_NORMAL_H_STR" InputMode="Pay2NumericInput.NumericInputMode.HoursMinutes" ToolTip="ساعت:دقیقه (مثال 32:35) یا عدد اعشاری (مثال 32.5)" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
+                                <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.OT_HOLIDAY_H_STR" InputMode="Pay2NumericInput.NumericInputMode.HoursMinutes" ToolTip="ساعت:دقیقه (مثال 32:35) یا عدد اعشاری (مثال 32.5)" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
+                                <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.OT_ADMIN_H_STR" InputMode="Pay2NumericInput.NumericInputMode.HoursMinutes" ToolTip="ساعت:دقیقه (مثال 32:35) یا عدد اعشاری (مثال 32.5)" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
 
                                 <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.LEAVE_DAYS_STR" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>
                                 <td><Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="item.ABSENT_DAYS_STR" CssClass="p2-grid-input" Disabled="@(item.LOCKED || PeriodData.Period.IsReadOnly)" /></td>

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
@@ -1,6 +1,8 @@
 ﻿@using Safir.Shared.Models.Salary
 @using Safir.Shared.Models
 @inject Safir.Client.Services.Pay2EmployeeApiService EmployeeApi
+@inject Safir.Client.Services.Pay2ItemDefApiService ItemDefApi
+@inject Safir.Client.Services.Pay2SettingsApiService SettingsApi
 @inject ISnackbar Snackbar
 @inject MudBlazor.IDialogService DialogService
 
@@ -47,20 +49,46 @@
                         <i class="bi bi-cash-stack"></i> افزودن / ویرایش آیتم حقوقی
                     </div>
 
-                    <div class="form-grid-2 p2-mb-16">
+                    <div class="form-grid-3 p2-mb-16">
                         <div class="form-field">
                             <label>انتخاب آیتم (PAY2_ITEM_DEF) *</label>
                             <!-- 🚀 قفل شدن فرم در صورت تایید حکم -->
                             <Pay2Select TItem="LookupDto<int>" TValue="int" Items="ItemDefs"
                                         @bind-Value="CurrentLine.ITEM_ID"
+                                        @bind-Value:after="OnItemChanged"
                                         TextSelector="x => x.Name" ValueSelector="x => x.Id"
                                         Placeholder="— انتخاب کنید —" Clearable="false"
                                         Disabled="@(IsEditing || IsDecreeConfirmed)" />
                         </div>
                         <div class="form-field">
-                            <label>مبلغ در این حکم (ریال) *</label>
-                            <Pay2NumericInput @bind-Value="CurrentAmountStr" MaxLength="16" Direction="ltr" IsDigitGroupActive="true" ThreeTwoZero="true" Disabled="@IsDecreeConfirmed" />
+                            <label>@(IsShiftPctItem ? "درصد از حقوق پایه ماهیانه (٪) *" : "مبلغ در این حکم (ریال) *")</label>
+                            <Pay2NumericInput @bind-Value="CurrentAmountStr" @bind-Value:after="OnAmountManuallyChanged"
+                                              MaxLength="@(IsShiftPctItem ? 3 : 16)" Direction="ltr"
+                                              IsDigitGroupActive="@(!IsShiftPctItem)" ThreeTwoZero="@(!IsShiftPctItem)"
+                                              Placeholder="@(IsShiftPctItem ? "مثال: 10" : null)"
+                                              ToolTip="@(IsShiftPctItem ? "حق شیفت به صورت درصدی از حقوق پایه ماهیانه (نرخ روزانه × ۳۰) محاسبه می‌شود — مانند حکم قبلی فقط عدد درصد را وارد کنید" : null)"
+                                              Disabled="@IsDecreeConfirmed" />
+                            @if (IsShiftPctItem && !string.IsNullOrWhiteSpace(ShiftHint))
+                            {
+                                <div style="font-size:11px; color:var(--p2-text-muted); margin-top:4px;">@ShiftHint</div>
+                            }
                         </div>
+                        @if (!IsShiftPctItem && IsMonthlyBasisSelected)
+                        {
+                            <div class="form-field">
+                                <label>درصد از حقوق ماهیانه (٪)</label>
+                                <Pay2NumericInput @bind-Value="CurrentPercentStr" @bind-Value:after="ApplyPercentToAmount"
+                                                  InputMode="Pay2NumericInput.NumericInputMode.Percentage"
+                                                  MaxLength="3" MaxDecimalPlaces="2" Direction="ltr"
+                                                  Placeholder="مثال: 10"
+                                                  ToolTip="با وارد کردن درصد، مبلغ به صورت خودکار از روی حقوق پایه ماهیانه این حکم محاسبه و در فیلد مبلغ قرار می‌گیرد"
+                                                  Disabled="@IsDecreeConfirmed" />
+                                @if (!string.IsNullOrWhiteSpace(PercentHint))
+                                {
+                                    <div style="font-size:11px; color:var(--p2-text-muted); margin-top:4px;">@PercentHint</div>
+                                }
+                            </div>
+                        }
                     </div>
 
                     <div style="background: var(--p2-bg-white); border: 1px solid var(--p2-border); border-radius: var(--p2-radius-md); padding: 16px; margin-bottom: 16px;">
@@ -128,7 +156,16 @@
                                 {
                                     <tr style="background: @(CurrentLine.ITEM_ID == item.ITEM_ID ? "var(--p2-primary-light)" : "transparent")">
                                         <td><b>@item.ITEM_NAME</b></td>
-                                        <td class="p2-text-mono p2-text-primary" style="text-align:center; font-weight:bold;">@item.AMOUNT.ToString("N0")</td>
+                                        <td class="p2-text-mono p2-text-primary" style="text-align:center; font-weight:bold;">
+                                            @if (IsShiftPctLine(item))
+                                            {
+                                                <span>@item.AMOUNT٪</span>
+                                            }
+                                            else
+                                            {
+                                                <span>@item.AMOUNT.ToString("N0")</span>
+                                            }
+                                        </td>
                                         <td style="text-align:center; color: var(--p2-text-muted);">@item.InsText</td>
                                         <td style="text-align:center; color: var(--p2-text-muted);">@item.TaxText</td>
                                         <td style="text-align:center; color: var(--p2-text-muted);">@item.BasisText</td>
@@ -169,11 +206,24 @@
 
     List<Pay2DecreeLineDto> Lines = new();
     List<LookupDto<int>> ItemDefs = new();
+    List<Pay2ItemDefDto> FullItemDefs = new();
     Pay2DecreeLineDto CurrentLine = new();
 
     string? CurrentAmountStr;
+    string? CurrentPercentStr;
+    string? PercentHint;
+    string? ShiftHint;
+    string _shiftMode = "PCT"; // SHIFT_MODE از PAY2_CONFIG: PCT=درصدی | FIXED=مبلغ ثابت
     bool IsSaving = false;
     bool IsEditing = false;
+
+    Pay2ItemDefDto? SelectedDef => FullItemDefs.FirstOrDefault(d => d.ITEM_ID == CurrentLine.ITEM_ID);
+
+    // در حالت PCT، موتور محاسبه (SP_PAY2_CALC_RUN) مبلغ آیتم SHIFT را «درصد» تفسیر می‌کند
+    bool IsShiftPctItem => IsShiftPctLine(CurrentLine);
+
+    // کمک‌محاسبه درصد فقط برای آیتم‌هایی که مبنای مؤثرشان ماهیانه است (مبلغ = ریالِ کامل ماه)
+    bool IsMonthlyBasisSelected => SelectedDef != null && (CurrentLine.BASIS_OV ?? SelectedDef.CALC_BASIS) == 2;
 
     private int _lastProcessedDecId = -1;
     private bool _lastOpenState = false;
@@ -185,7 +235,7 @@
         new(3, "طبق تعریف پایه"), new(1, "مشمول"), new(2, "معاف")
     };
     List<LookupDto<int>> BasisOptions = new() {
-        new(3, "طبق تعریف پایه"), new(1, "روزانه"), new(2, "ماهیانه")
+        new(9, "طبق تعریف پایه"), new(1, "روزانه"), new(2, "ماهیانه"), new(3, "ساعتی")
     };
 
     protected override async Task OnParametersSetAsync()
@@ -212,8 +262,18 @@
         try
         {
             // منتظر می‌مانیم تا هم لیست تعاریف آیتم‌ها و هم اقلام ریالی این حکم به طور کامل لود شوند
-            ItemDefs = await EmployeeApi.GetItemDefsLookupAsync();
-            Lines = await EmployeeApi.GetDecreeLinesAsync(DecreeId);
+            // چهار فراخوانی مستقل به صورت موازی اجرا می‌شوند تا باز شدن مودال سریع‌تر باشد
+            var itemDefsTask = EmployeeApi.GetItemDefsLookupAsync();
+            var linesTask = EmployeeApi.GetDecreeLinesAsync(DecreeId);
+            var fullDefsTask = ItemDefApi.GetItemDefsAsync();
+            var shiftModeTask = LoadShiftModeAsync();
+
+            await Task.WhenAll(itemDefsTask, linesTask, fullDefsTask, shiftModeTask);
+
+            ItemDefs = itemDefsTask.Result;
+            Lines = linesTask.Result;
+            FullItemDefs = fullDefsTask.Result;
+            _shiftMode = shiftModeTask.Result;
         }
         catch (Exception ex)
         {
@@ -231,7 +291,100 @@
     {
         CurrentLine = new Pay2DecreeLineDto();
         CurrentAmountStr = null;
+        CurrentPercentStr = null;
+        PercentHint = null;
+        ShiftHint = null;
         IsEditing = false;
+    }
+
+    // محاسبه «حقوق پایه ماهیانه» این حکم از روی آیتم حقوق پایه
+    // موتور محاسبه برای حق شیفت از BASE_SAL_B (حقوق روزانه رسمی) استفاده می‌کند؛
+    // مبنای روزانه در ۳۰ ضرب می‌شود تا مبلغ ماهیانه به دست آید
+    long? GetMonthlyBaseSalary()
+    {
+        var baseDef = FullItemDefs.FirstOrDefault(d => d.ITEM_CODE == "BASE_SAL_B")
+                   ?? FullItemDefs.FirstOrDefault(d => d.ITEM_CODE == "BASE_SAL");
+        if (baseDef == null) return null;
+
+        var baseLine = Lines.FirstOrDefault(l => l.ITEM_ID == baseDef.ITEM_ID);
+        if (baseLine == null || baseLine.AMOUNT <= 0) return null;
+
+        byte effectiveBasis = baseLine.BASIS_OV ?? baseDef.CALC_BASIS;
+        return effectiveBasis == 1 ? baseLine.AMOUNT * 30 : baseLine.AMOUNT;
+    }
+
+    void OnItemChanged()
+    {
+        CurrentPercentStr = null;
+        PercentHint = null;
+        ShiftHint = null;
+    }
+
+    bool IsShiftPctLine(Pay2DecreeLineDto line)
+    {
+        if (string.Equals(_shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase)) return false;
+        var def = FullItemDefs.FirstOrDefault(d => d.ITEM_ID == line.ITEM_ID);
+        return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
+    }
+
+    async Task<string> LoadShiftModeAsync()
+    {
+        try
+        {
+            var configs = await SettingsApi.GetConfigsAsync();
+            return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
+        }
+        catch { return "PCT"; }
+    }
+
+    // منطق مشترک «درصد × حقوق پایه ماهیانه» برای هر دو کمک‌محاسبه (شیفت و عمومی)
+    (long? Computed, string Hint) CalcPercentOfMonthly(decimal pct)
+    {
+        var monthlyBase = GetMonthlyBaseSalary();
+        if (monthlyBase == null)
+            return (null, "آیتم «حقوق پایه» در اقلام این حکم یافت نشد؛ ابتدا حقوق پایه را ثبت کنید.");
+
+        long computed = (long)Math.Round(monthlyBase.Value * pct / 100m, MidpointRounding.AwayFromZero);
+        return (computed, $"{pct:0.##}٪ × حقوق پایه ماهیانه {monthlyBase.Value:N0} = {computed:N0} ریال");
+    }
+
+    void ApplyPercentToAmount()
+    {
+        PercentHint = null;
+
+        if (string.IsNullOrWhiteSpace(CurrentPercentStr)) return;
+
+        if (!decimal.TryParse(CurrentPercentStr, System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture, out decimal pct) || pct <= 0)
+            return;
+
+        var (computed, hint) = CalcPercentOfMonthly(pct);
+        PercentHint = hint;
+        if (computed.HasValue) CurrentAmountStr = computed.Value.ToString();
+    }
+
+    void OnAmountManuallyChanged()
+    {
+        if (IsShiftPctItem)
+        {
+            UpdateShiftHint();
+            return;
+        }
+
+        // اگر کاربر مبلغ را دستی تغییر داد، درصد قبلی دیگر معتبر نیست
+        CurrentPercentStr = null;
+        PercentHint = null;
+    }
+
+    void UpdateShiftHint()
+    {
+        ShiftHint = null;
+
+        if (!long.TryParse(CurrentAmountStr?.Replace(",", ""), out long pct) || pct <= 0)
+            return;
+
+        var (computed, hint) = CalcPercentOfMonthly(pct);
+        ShiftHint = computed.HasValue ? hint + " (برای ماه کامل)" : hint;
     }
 
     void EditLine(Pay2DecreeLineDto item)
@@ -250,6 +403,10 @@
         };
 
         CurrentAmountStr = CurrentLine.AMOUNT.ToString();
+        CurrentPercentStr = null;
+        PercentHint = null;
+        ShiftHint = null;
+        if (IsShiftPctItem) UpdateShiftHint();
         IsEditing = true;
 
         StateHasChanged();

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
@@ -144,7 +144,7 @@
     bool _lastOpenState = false;
 
     List<LookupDto<int>> OverrideOptions = new() { new(3, "طبق تعریف پایه"), new(1, "مشمول"), new(2, "معاف") };
-    List<LookupDto<int>> BasisOptions = new() { new(3, "طبق تعریف پایه"), new(1, "روزانه"), new(2, "ماهیانه") };
+    List<LookupDto<int>> BasisOptions = new() { new(9, "طبق تعریف پایه"), new(1, "روزانه"), new(2, "ماهیانه"), new(3, "ساعتی") };
 
     protected override async Task OnParametersSetAsync()
     {

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/LeaveRequestModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/LeaveRequestModal.razor
@@ -30,7 +30,7 @@
                 <div class="form-grid-3 p2-mb-16">
                     <div class="form-field">
                         <label>نوع مرخصی *</label>
-                        <Pay2Select TItem="LookupDto<byte>" TValue="byte" Items="LeaveTypeOptions" @bind-Value="CurrentLeave.LEV_TYPE" TextSelector="x => x.Name" ValueSelector="x => x.Id" Clearable="false" />
+                        <Pay2Select TItem="LookupDto<byte>" TValue="byte" Items="LeaveTypeOptions" @bind-Value="CurrentLeave.LEV_TYPE" @bind-Value:after="OnLeaveTypeChanged" TextSelector="x => x.Name" ValueSelector="x => x.Id" Clearable="false" />
                     </div>
                     <div class="form-field">
                         <label>تاریخ شروع (شمسی) *</label>
@@ -44,8 +44,9 @@
 
                 <div class="form-grid-3 p2-mb-16">
                     <div class="form-field">
-                        <label>روز *</label>
-                        <Pay2NumericInput @bind-Value="ReqDaysStr" MaxLength="3" Direction="ltr" />
+                        <label>روز @(IsHourlyLeave ? "" : "*")</label>
+                        <Pay2NumericInput @bind-Value="ReqDaysStr" MaxLength="3" Direction="ltr" Disabled="@IsHourlyLeave"
+                                          ToolTip="@(IsHourlyLeave ? "در مرخصی ساعتی، روز قابل ثبت نیست" : null)" />
                     </div>
                     <div class="form-field">
                         <label>ساعت</label>
@@ -56,6 +57,14 @@
                         <Pay2NumericInput @bind-Value="ReqMinsStr" MaxLength="2" Direction="ltr" />
                     </div>
                 </div>
+
+                @if (IsHourlyLeave)
+                {
+                    <div style="background: var(--p2-info-bg); border: 1px solid var(--p2-info-border); border-radius: var(--p2-radius-md); padding: 10px 14px; margin-bottom: 16px; font-size: 12.5px; color: var(--p2-text-main);">
+                        <i class="bi bi-clock" style="color: var(--p2-primary);"></i>
+                        حداکثر مرخصی ساعتی قابل ثبت در هر درخواست <b>۳ ساعت و ۲۰ دقیقه</b> است.
+                    </div>
+                }
 
                 <div class="form-grid-3 p2-mb-16">
                     <div class="form-field" style="grid-column: span 2;">
@@ -183,8 +192,20 @@
     private bool _isDataLoaded = false;
 
     List<LookupDto<byte>> LeaveTypeOptions = new() {
-        new(1, "استحقاقی"), new(2, "استعلاجی"), new(3, "بدون حقوق"), new(4, "زایمان"), new(5, "مأموریت")
+        new(1, "استحقاقی"), new(2, "استعلاجی"), new(3, "بدون حقوق"), new(4, "زایمان"), new(5, "مأموریت"), new(Pay2LeaveDto.HOURLY_TYPE, "ساعتی")
     };
+
+    bool IsHourlyLeave => CurrentLeave.LEV_TYPE == Pay2LeaveDto.HOURLY_TYPE;
+
+    void OnLeaveTypeChanged()
+    {
+        if (IsHourlyLeave)
+        {
+            // در مرخصی ساعتی روز معنا ندارد و تاریخ پایان همان روز شروع است
+            ReqDaysStr = "0";
+            EndDateStr = StartDateStr;
+        }
+    }
     List<LookupDto<byte>> StatusOptions = new() {
         new(1, "ثبت اولیه"), new(2, "تأیید درخواست"), new(3, "تأیید مدیر واحد"), new(4, "تأیید مدیرعامل")
     };
@@ -282,6 +303,13 @@
         byte.TryParse(ReqHoursStr, out byte h);
         byte.TryParse(ReqMinsStr, out byte m);
 
+        if (IsHourlyLeave)
+        {
+            // مرخصی ساعتی همیشه تک‌روزه است؛ تاریخ پایان با شروع یکسان می‌شود
+            eDate = sDate;
+            EndDateStr = StartDateStr;
+        }
+
         if (sDate <= 13000000 || eDate <= 13000000)
         {
             Snackbar.Add("تاریخ شروع و پایان نامعتبر است.", MudBlazor.Severity.Warning); return;
@@ -289,6 +317,21 @@
         if (d == 0 && h == 0 && m == 0)
         {
             Snackbar.Add("مدت مرخصی (روز/ساعت/دقیقه) نمی‌تواند صفر باشد.", MudBlazor.Severity.Warning); return;
+        }
+        if (m >= 60)
+        {
+            Snackbar.Add("دقیقه باید کمتر از ۶۰ باشد.", MudBlazor.Severity.Warning); return;
+        }
+        if (IsHourlyLeave)
+        {
+            if (d > 0)
+            {
+                Snackbar.Add("در مرخصی ساعتی امکان ثبت روز وجود ندارد.", MudBlazor.Severity.Warning); return;
+            }
+            if ((h * 60) + m > Pay2LeaveDto.HOURLY_MAX_MINUTES)
+            {
+                Snackbar.Add("مرخصی ساعتی نمی‌تواند بیشتر از ۳ ساعت و ۲۰ دقیقه (۳:۲۰) باشد.", MudBlazor.Severity.Warning); return;
+            }
         }
 
         CurrentLeave.EMP_ID = EmployeeId;

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/OverrideModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/OverrideModal.razor
@@ -166,7 +166,7 @@
         new(3, "بدون تغییر (طبق تعریف آیتم)"), new(1, "مشمول"), new(2, "معاف")
     };
     List<LookupDto<int>> BasisOptions = new() {
-        new(3, "بدون تغییر (طبق تعریف آیتم)"), new(1, "روزانه"), new(2, "ماهیانه")
+        new(9, "بدون تغییر (طبق تعریف آیتم)"), new(1, "روزانه"), new(2, "ماهیانه"), new(3, "ساعتی")
     };
 
     protected override async Task OnParametersSetAsync()

--- a/Client/Pages/Salary/Tabs/ItemDefTab.razor
+++ b/Client/Pages/Salary/Tabs/ItemDefTab.razor
@@ -263,7 +263,7 @@
     };
 
     List<LookupDto<byte>> CalcBasisOptions = new() {
-        new(1, "1 — روزانه"), new(2, "2 — ماهیانه (مبلغ کامل)")
+        new(1, "1 — روزانه"), new(2, "2 — ماهیانه (مبلغ کامل)"), new(3, "3 — ساعتی (مبلغ × ساعت کارکرد)")
     };
 
     List<LookupDto<byte>> BaseDaysOptions = new() {

--- a/Client/Pages/Salary/Tabs/Pay2NumericInput.razor
+++ b/Client/Pages/Salary/Tabs/Pay2NumericInput.razor
@@ -23,7 +23,7 @@
        @onkeydown="HandleKeyDownAsync" />
 
 @code {
-    public enum NumericInputMode { None, Amount, PersianDate, Percentage }
+    public enum NumericInputMode { None, Amount, PersianDate, Percentage, HoursMinutes }
 
     private ElementReference _inputRef;
     private IJSObjectReference? _module;
@@ -66,7 +66,7 @@
         ? "pay2-input"
         : $"pay2-input {CssClass}";
 
-    private string InputModeValue => InputMode == NumericInputMode.Percentage ? "decimal" : "numeric";
+    private string InputModeValue => InputMode is NumericInputMode.Percentage or NumericInputMode.HoursMinutes ? "decimal" : "numeric";
 
     private int? EffectiveMaxLength => InputMode switch
     {
@@ -101,7 +101,8 @@
         {
             try
             {
-                _module = await JS.InvokeAsync<IJSObjectReference>("import", "./js/pay2-input-guards.js");
+                // نسخه‌گذاری برای ابطال کش مرورگر پس از تغییر گارد ورودی (پشتیبانی از «:»)
+                _module = await JS.InvokeAsync<IJSObjectReference>("import", "./js/pay2-input-guards.js?v=14050323-1");
                 _jsGuardLoaded = true;
             }
             catch (Exception ex)
@@ -138,7 +139,8 @@
             await _module.InvokeVoidAsync("attachInputGuard", _inputRef, new
             {
                 maxLength = EffectiveMaxLength ?? 0,
-                allowDecimal = InputMode == NumericInputMode.Percentage,
+                allowDecimal = InputMode is NumericInputMode.Percentage or NumericInputMode.HoursMinutes,
+                allowTime = InputMode == NumericInputMode.HoursMinutes,
                 maxDecimalPlaces = SafeMaxDecimalPlaces,
                 threeTwoZero = ThreeTwoZero && InputMode != NumericInputMode.PersianDate,
                 persianDate = InputMode == NumericInputMode.PersianDate
@@ -157,7 +159,7 @@
         if (InputMode == NumericInputMode.PersianDate && normalized?.Length > 8)
             normalized = normalized[..8];
 
-        if (InputMode == NumericInputMode.Percentage)
+        if (InputMode is NumericInputMode.Percentage or NumericInputMode.HoursMinutes)
             normalized = LimitDecimalPlaces(normalized, SafeMaxDecimalPlaces);
 
         _displayText = normalized;
@@ -239,10 +241,38 @@
             NumericInputMode.Percentage when decimal.TryParse(value, NumberStyles.Number, inv, out var pct)
                 => TruncateDecimal(pct, SafeMaxDecimalPlaces).ToString(inv),
 
+            NumericInputMode.HoursMinutes => NormalizeHoursMinutes(value),
+
             NumericInputMode.None => value,
 
             _ => null
         };
+    }
+
+    // اعتبارسنجی فرمت «ساعت:دقیقه» (مثال 32:35) یا عدد اعشاری (مثال 32.5)
+    private static string? NormalizeHoursMinutes(string value)
+    {
+        var inv = CultureInfo.InvariantCulture;
+
+        if (value.Contains(':'))
+        {
+            var parts = value.Split(':');
+            if (parts.Length != 2) return null;
+
+            if (!int.TryParse(parts[0], NumberStyles.None, inv, out var h)) return null;
+
+            // «32:» را معادل «32» در نظر می‌گیریم
+            if (string.IsNullOrEmpty(parts[1])) return h.ToString(inv);
+
+            if (!int.TryParse(parts[1], NumberStyles.None, inv, out var m)) return null;
+            if (m > 59) return null;
+            return $"{h}:{m:D2}";
+        }
+
+        if (decimal.TryParse(value, NumberStyles.Number, inv, out var dec))
+            return TruncateDecimal(dec, 2).ToString(inv);
+
+        return null;
     }
 
     private bool IsValidFinalValue(string? value)
@@ -305,18 +335,25 @@
                 continue;
             }
 
-            if (InputMode == NumericInputMode.Percentage &&
+            if (InputMode is NumericInputMode.Percentage or NumericInputMode.HoursMinutes &&
                 (ch == '.' || ch == '/' || ch == '٫' || ch == ',') &&
                 !hasDot)
             {
                 sb.Append('.');
                 hasDot = true;
             }
+
+            // در حالت ساعت:دقیقه، کاراکتر «:» به عنوان جداکننده دقیقه مجاز است
+            if (InputMode == NumericInputMode.HoursMinutes && ch == ':' && !hasDot)
+            {
+                sb.Append(':');
+                hasDot = true;
+            }
         }
 
         var result = sb.ToString();
 
-        if (InputMode == NumericInputMode.Percentage)
+        if (InputMode is NumericInputMode.Percentage or NumericInputMode.HoursMinutes)
             result = LimitDecimalPlaces(result, SafeMaxDecimalPlaces);
 
         if (InputMode == NumericInputMode.PersianDate && result.Length > 8)
@@ -348,6 +385,14 @@
     {
         if (string.IsNullOrWhiteSpace(value))
             return value;
+
+        // در فرمت ساعت:دقیقه حداکثر دو رقم بعد از «:» مجاز است
+        var colonIndex = value.IndexOf(':');
+        if (colonIndex >= 0)
+        {
+            var allowedColonLength = colonIndex + 1 + 2;
+            return value.Length > allowedColonLength ? value[..allowedColonLength] : value;
+        }
 
         var dotIndex = value.IndexOf('.');
         if (dotIndex < 0)

--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -629,6 +629,7 @@
     <script src="js/cleanup.js"></script>
     <script src="js/interop.js"></script>
     <script src="js/diagnostics.js"></script>
+    <script src="js/pay2-enter-nav.js?v=14050323-1"></script>
 
     <!--فعلا کامنت شده برای جلوگیری از کش شده-->
     <!--<script>navigator.serviceWorker.register('service-worker.js');</script>-->

--- a/Client/wwwroot/js/pay2-enter-nav.js
+++ b/Client/wwwroot/js/pay2-enter-nav.js
@@ -1,0 +1,51 @@
+// ════════════════════════════════════════════════════════════════
+// ناوبری با کلید Enter در فرم‌های حقوق و دستمزد (Pay2)
+// با زدن Enter فوکوس به فیلد بعدی منتقل می‌شود و نیازی به موس نیست.
+// فقط روی ورودی‌های ماژول Pay2 اعمال می‌شود تا سایر بخش‌ها تغییری نکنند.
+// ════════════════════════════════════════════════════════════════
+(function () {
+    // کلاس‌های ورودی ماژول Pay2 — مبنای مشترک هر دو سلکتور پایین
+    const PAY2_INPUT_CLASSES =
+        "input.pay2-input, input.p2-grid-input, input.pay2-select-input, input.pay2-search-input";
+
+    const FOCUSABLE_SELECTOR =
+        PAY2_INPUT_CLASSES + ", " +
+        ".pay2-tab-container input:not([type=checkbox]):not([type=radio]), " +
+        ".pay2-modal-container input:not([type=checkbox]):not([type=radio])";
+
+    function isFocusable(el) {
+        if (el.disabled || el.readOnly) return false;
+        if (el.getAttribute("tabindex") === "-1") return false;
+        // المان‌های مخفی (داخل مودال‌های بسته و ...) قابل فوکوس نیستند
+        return el.offsetParent !== null;
+    }
+
+    document.addEventListener("keydown", function (e) {
+        if (e.key !== "Enter" || e.shiftKey || e.ctrlKey || e.altKey || e.isComposing) return;
+
+        const target = e.target;
+        if (!target || !target.matches || !target.matches(PAY2_INPUT_CLASSES)) return;
+
+        // اگر دراپ‌داون Pay2Select باز است، هندلر Blazor ابتدا آیتم را انتخاب می‌کند؛
+        // سپس فوکوس به فیلد بعدی می‌رود.
+        // querySelectorAll بدون تکرار و به ترتیب DOM برمی‌گرداند.
+        const candidates = Array.from(document.querySelectorAll(FOCUSABLE_SELECTOR))
+            .filter(isFocusable);
+
+        const index = candidates.indexOf(target);
+        if (index < 0) return;
+
+        e.preventDefault();
+
+        const next = candidates[index + 1];
+        if (!next) return;
+
+        next.focus();
+
+        try {
+            if (typeof next.select === "function") next.select();
+        } catch {
+            // ignored
+        }
+    });
+})();

--- a/Client/wwwroot/js/pay2-input-guards.js
+++ b/Client/wwwroot/js/pay2-input-guards.js
@@ -19,6 +19,7 @@ function normalizeText(text, options, currentValue, selectionStart, selectionEnd
     if (!text) return "";
 
     const allowDecimal = options.allowDecimal === true;
+    const allowTime = options.allowTime === true;
     const maxDecimalPlaces = Math.max(0, options.maxDecimalPlaces ?? 0);
     const persianDate = options.persianDate === true;
 
@@ -29,7 +30,8 @@ function normalizeText(text, options, currentValue, selectionStart, selectionEnd
     const valueAfterSelectionRemoved =
         safeCurrent.substring(0, start) + safeCurrent.substring(end);
 
-    let hasDecimal = valueAfterSelectionRemoved.includes(".");
+    let hasDecimal = valueAfterSelectionRemoved.includes(".") ||
+        (allowTime && valueAfterSelectionRemoved.includes(":"));
     let result = "";
 
     for (const ch of text) {
@@ -43,6 +45,13 @@ function normalizeText(text, options, currentValue, selectionStart, selectionEnd
         if (!persianDate && allowDecimal && (ch === "." || ch === "/" || ch === "٫" || ch === ",")) {
             if (!hasDecimal) {
                 result += ".";
+                hasDecimal = true;
+            }
+        }
+
+        if (!persianDate && allowTime && ch === ":") {
+            if (!hasDecimal) {
+                result += ":";
                 hasDecimal = true;
             }
         }
@@ -76,6 +85,14 @@ function limitByMaxLength(current, start, end, insertText, maxLength) {
 }
 
 function fixDecimalPlaces(value, maxDecimalPlaces) {
+    // در فرمت ساعت:دقیقه حداکثر دو رقم بعد از «:» مجاز است
+    const colonIndex = value.indexOf(":");
+    if (colonIndex >= 0) {
+        const intPart = value.substring(0, colonIndex);
+        const minPart = value.substring(colonIndex + 1).replace(/[:.]/g, "");
+        return intPart + ":" + minPart.substring(0, 2);
+    }
+
     const dotIndex = value.indexOf(".");
     if (dotIndex < 0) return value;
 
@@ -135,6 +152,7 @@ export function attachInputGuard(el, options) {
     const safeOptions = {
         maxLength: Math.max(0, options?.maxLength ?? 0),
         allowDecimal: options?.allowDecimal === true,
+        allowTime: options?.allowTime === true,
         maxDecimalPlaces: Math.max(0, options?.maxDecimalPlaces ?? 0),
         threeTwoZero: options?.threeTwoZero === true,
         persianDate: options?.persianDate === true

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -40,18 +40,18 @@ namespace Safir.Server.Controllers
         {
             try
             {
+                // ⚠️ بدون TOP: محدودیت قبلی (TOP 50) باعث می‌شد بخشی از مشاغل (مثل «کارمند اداری») هرگز در لیست ظاهر نشوند
                 string sql = @"
-            SELECT TOP 50 
-                   JOB_ID AS Id, 
-                   JOB_NAME AS Name 
-            FROM   PAY2_JOB 
+            SELECT JOB_ID AS Id,
+                   JOB_NAME AS Name
+            FROM   PAY2_JOB
             WHERE  IS_ACTIVE = 1";
 
                 object? parameters = null;
 
                 if (!string.IsNullOrWhiteSpace(searchTerm))
                 {
-                    sql += " AND JOB_NAME LIKE @Search";
+                    sql += " AND (JOB_NAME LIKE @Search OR JOB_CODE LIKE @Search)";
                     parameters = new { Search = $"%{searchTerm.Trim()}%" };
                 }
 
@@ -379,6 +379,22 @@ namespace Safir.Server.Controllers
         {
             var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
             if (!int.TryParse(userIdString, out int userCod)) return Unauthorized();
+
+            // 🚀 اعتبارسنجی مرخصی ساعتی: روز ممنوع و حداکثر ۳:۲۰ (۲۰۰ دقیقه)
+            if (leave.LEV_TYPE == Pay2LeaveDto.HOURLY_TYPE)
+            {
+                if (leave.REQ_DAYS > 0)
+                    return BadRequest("در مرخصی ساعتی امکان ثبت روز وجود ندارد.");
+
+                if ((leave.REQ_HOURS * 60) + leave.REQ_MINUTES > Pay2LeaveDto.HOURLY_MAX_MINUTES)
+                    return BadRequest("مرخصی ساعتی نمی‌تواند بیشتر از ۳ ساعت و ۲۰ دقیقه (۳:۲۰) باشد.");
+
+                // مرخصی ساعتی همیشه تک‌روزه است
+                leave.END_DATE = leave.START_DATE;
+            }
+
+            if (leave.REQ_MINUTES >= 60)
+                return BadRequest("دقیقه باید کمتر از ۶۰ باشد.");
 
             try
             {

--- a/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
+++ b/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
@@ -1,0 +1,440 @@
+-- ============================================================================
+-- PAY2 v6.1 — پشتیبانی از مبنای محاسبه «ساعتی» و حق شیفت درصدی از حقوق ماهیانه
+--
+-- این اسکریپت پس از PAY2_DDL_v6.sql و PAY2_Procedures_v6.sql اجرا می‌شود
+-- (یا محتوای آن جایگزین SP_PAY2_CALC_RUN در اسکریپت SalaryScript گردد).
+--
+-- تغییرات نسبت به v6.0:
+--   ۱. CALC_BASIS / BASIS_OV مقدار 3 = «ساعتی» را می‌پذیرد (قید CK_CALC_BASIS باز شد)
+--   ۲. در موتور محاسبه، آیتم حکم با مبنای ساعتی این‌گونه محاسبه می‌شود:
+--        OT_NORMAL  → نرخ ساعتی حکم × OT_NORMAL_H کارکرد
+--        OT_HOLIDAY → نرخ ساعتی حکم × OT_HOLIDAY_H کارکرد
+--        OT_ADMIN   → نرخ ساعتی حکم × OT_ADMIN_H کارکرد
+--        سایر       → نرخ ساعتی حکم × (روز کارکرد × OT_HOUR_BASE)
+--      توجه: نرخ ساعتی ثبت‌شده در حکم نرخ نهایی است و ضریب 1.4 روی آن اعمال نمی‌شود.
+--   ۳. اگر آیتم اضافه‌کار صریحاً در حکم باشد، محاسبه خودکار از روی حقوق پایه
+--      انجام نمی‌شود (جلوگیری از دوبار منظور شدن).
+--   ۴. حق شیفت (SHIFT) با SHIFT_MODE=PCT اکنون «درصدی از حقوق پایه ماهیانه»
+--      (نرخ روزانه × ۳۰) با تناسب روز کارکرد است — فرمول قبلی عملاً درصدی از
+--      دستمزد روزانه را می‌داد. در SHIFT_MODE=FIXED مبلغ ثابت روزشمار است.
+--   ۵. رفع باگ موروثی v6.0: نشت متغیرهای استثنا (PAY2_OVERRIDE) از یک آیتم به
+--      آیتم‌های بعدی همان حکم وقتی برای آیتم بعدی استثنایی وجود نداشت
+--      + افزودن ORDER BY به TOP 1 برای انتخاب قطعیِ جدیدترین استثنا.
+--
+-- ⚠️ نکته مهاجرت: پس از اجرای این اسکریپت، مقدار آیتم «حق شیفت» در احکامِ موجود
+--    به معنای «درصد از حقوق پایه ماهیانه» تفسیر می‌شود؛ مقادیر قبلی را بازبینی کنید.
+-- ============================================================================
+
+-- ── ۱. باز کردن قید CK_CALC_BASIS برای مقدار 3 (ساعتی) ─────────────────────
+IF EXISTS (SELECT 1 FROM sys.check_constraints
+           WHERE name = 'CK_CALC_BASIS'
+             AND parent_object_id = OBJECT_ID(N'dbo.PAY2_ITEM_DEF')
+             AND definition NOT LIKE '%(3)%')
+BEGIN
+    ALTER TABLE dbo.PAY2_ITEM_DEF DROP CONSTRAINT CK_CALC_BASIS;
+    ALTER TABLE dbo.PAY2_ITEM_DEF ADD CONSTRAINT CK_CALC_BASIS CHECK ([CALC_BASIS] IN (1,2,3));
+END;
+GO
+
+-- ── ۲. سایر قیدهای احتمالی روی BASIS_OV که مقدار 3 را مجاز نمی‌دانند ────────
+DECLARE @sql NVARCHAR(MAX) = N'';
+SELECT @sql = @sql + N'ALTER TABLE ' + QUOTENAME(OBJECT_SCHEMA_NAME(cc.parent_object_id))
+            + N'.' + QUOTENAME(OBJECT_NAME(cc.parent_object_id))
+            + N' DROP CONSTRAINT ' + QUOTENAME(cc.name) + N';' + CHAR(10)
+FROM sys.check_constraints cc
+WHERE OBJECT_NAME(cc.parent_object_id) IN ('PAY2_DECREE_LINE', 'PAY2_OVERRIDE', 'PAY2_ITEM_TMPL_LINE')
+  AND cc.definition LIKE '%BASIS_OV%'
+  AND cc.definition NOT LIKE '%(3)%';
+
+IF LEN(@sql) > 0
+    EXEC sp_executesql @sql;
+GO
+
+-- ── ۳. موتور محاسبه حقوق — نسخه v6.1 ────────────────────────────────────────
+CREATE OR ALTER PROCEDURE [dbo].[SP_PAY2_CALC_RUN]
+    @WS_ID       INT,
+    @PER_ID      INT,
+    @PAYROLL_N_S FLOAT,
+    @CALC_BY     INT          = NULL,
+    @IS_RERUN    BIT          = 0,
+    @NEW_RUN_ID  INT          OUTPUT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+    SET ANSI_WARNINGS OFF;
+
+    -- گام ۱ — بارگذاری تنظیمات
+    DECLARE
+        @MONTH_DAYS_MODE   NVARCHAR(10), @MONTH_DAYS        TINYINT,
+        @OT_NORMAL_MULT    DECIMAL(6,4), @OT_HOLIDAY_MULT   DECIMAL(6,4),
+        @OT_HOUR_BASE      DECIMAL(6,4), @SHIFT_MODE        NVARCHAR(10),
+        @ROUND_MODE        INT,          @INS_WORKER_RATE   DECIMAL(6,4),
+        @INS_EMPLOYER_RATE DECIMAL(6,4), @INS_UNEMP_RATE    DECIMAL(6,4),
+        @INS_CEILING_APPLY BIT,          @INS_CEILING       BIGINT,
+        @TAX_YEAR          SMALLINT,     @TAX_EXEMPT        BIGINT,
+        @TAX_DEDUCT_INS    BIT,          @TAX_DEP_APPLY     BIT,
+        @ADV_ENABLED       BIT,          @PERIOD_DATE       BIGINT,
+        @PERIOD_MONTH      INT;
+
+    SELECT
+        @MONTH_DAYS_MODE   = ISNULL(MAX(CASE WHEN CFG_KEY='MONTH_DAYS_MODE'    THEN CFG_VALUE END), '30'),
+        @OT_NORMAL_MULT    = ISNULL(MAX(CASE WHEN CFG_KEY='OT_NORMAL_MULT'     THEN CAST(CFG_VALUE AS DECIMAL(6,4)) END), 1.40),
+        @OT_HOLIDAY_MULT   = ISNULL(MAX(CASE WHEN CFG_KEY='OT_HOLIDAY_MULT'    THEN CAST(CFG_VALUE AS DECIMAL(6,4)) END), 1.40),
+        @OT_HOUR_BASE      = ISNULL(MAX(CASE WHEN CFG_KEY='OT_HOUR_BASE'       THEN CAST(CFG_VALUE AS DECIMAL(6,4)) END), 7.33),
+        @SHIFT_MODE        = ISNULL(MAX(CASE WHEN CFG_KEY='SHIFT_MODE'         THEN CFG_VALUE END), 'PCT'),
+        @ROUND_MODE        = ISNULL(MAX(CASE WHEN CFG_KEY='ROUND_MODE'         THEN CAST(CFG_VALUE AS INT) END), 1),
+        @INS_WORKER_RATE   = ISNULL(MAX(CASE WHEN CFG_KEY='INS_WORKER_RATE'    THEN CAST(CFG_VALUE AS DECIMAL(6,4)) END) / 100.0, 0.07),
+        @INS_EMPLOYER_RATE = ISNULL(MAX(CASE WHEN CFG_KEY='INS_EMPLOYER_RATE'  THEN CAST(CFG_VALUE AS DECIMAL(6,4)) END) / 100.0, 0.20),
+        @INS_UNEMP_RATE    = ISNULL(MAX(CASE WHEN CFG_KEY='INS_UNEMP_RATE'     THEN CAST(CFG_VALUE AS DECIMAL(6,4)) END) / 100.0, 0.03),
+        @INS_CEILING       = ISNULL(MAX(CASE WHEN CFG_KEY='INS_CEILING_MONTHLY' THEN CAST(CFG_VALUE AS BIGINT) END), 999999999),
+        @TAX_YEAR          = ISNULL(MAX(CASE WHEN CFG_KEY='TAX_YEAR'           THEN CAST(CFG_VALUE AS SMALLINT) END), 1403),
+        @TAX_EXEMPT        = ISNULL(MAX(CASE WHEN CFG_KEY='TAX_EXEMPT_MONTHLY' THEN CAST(CFG_VALUE AS BIGINT) END), 0),
+        @INS_CEILING_APPLY = ISNULL(CAST(MAX(CASE WHEN CFG_KEY='INS_CEILING_APPLY'  THEN CAST(CFG_VALUE AS INT) END) AS BIT), 1),
+        @TAX_DEDUCT_INS    = ISNULL(CAST(MAX(CASE WHEN CFG_KEY='TAX_DEDUCT_INS'     THEN CAST(CFG_VALUE AS INT) END) AS BIT), 1),
+        @TAX_DEP_APPLY     = ISNULL(CAST(MAX(CASE WHEN CFG_KEY='TAX_DEPRIVATION_APPLY' THEN CAST(CFG_VALUE AS INT) END) AS BIT), 0),
+        @ADV_ENABLED       = ISNULL(CAST(MAX(CASE WHEN CFG_KEY='ADV_ENABLED'        THEN CAST(CFG_VALUE AS INT) END) AS BIT), 0)
+    FROM PAY2_CONFIG
+    WHERE CFG_KEY IN (
+        'MONTH_DAYS_MODE','OT_NORMAL_MULT','OT_HOLIDAY_MULT','OT_HOUR_BASE',
+        'SHIFT_MODE','ROUND_MODE','INS_WORKER_RATE','INS_EMPLOYER_RATE',
+        'INS_UNEMP_RATE','INS_CEILING_APPLY','INS_CEILING_MONTHLY',
+        'TAX_YEAR','TAX_EXEMPT_MONTHLY','TAX_DEDUCT_INS',
+        'TAX_DEPRIVATION_APPLY','ADV_ENABLED'
+    );
+
+    SELECT @PERIOD_DATE = PERIOD_DATE FROM PAY2_PERIOD WHERE PER_ID = @PER_ID;
+    IF @PERIOD_DATE IS NULL
+    BEGIN
+        RAISERROR(N'دوره %d یافت نشد.', 16, 1, @PER_ID);
+        RETURN;
+    END;
+
+    SET @MONTH_DAYS = CASE WHEN @MONTH_DAYS_MODE = '30' THEN 30 ELSE 30 END;
+    SET @PERIOD_MONTH = @PERIOD_DATE / 100;  
+
+    -- گام ۲ — ایجاد هدر PAY2_RUN
+    DECLARE @PREV_RUN_ID INT = NULL;
+    DECLARE @NEXT_RUN_NO SMALLINT = 1;
+
+    IF @IS_RERUN = 1
+    BEGIN
+        SELECT TOP 1
+            @PREV_RUN_ID = RUN_ID,
+            @NEXT_RUN_NO = RUN_NO + 1
+        FROM PAY2_RUN
+        WHERE PER_ID = @PER_ID AND IS_LATEST = 1
+        ORDER BY RUN_NO DESC;
+
+        UPDATE PAY2_RUN SET IS_LATEST = 0 WHERE PER_ID = @PER_ID;
+    END;
+
+    INSERT INTO PAY2_RUN (PER_ID, RUN_NO, IS_LATEST, CALC_AT, CALC_BY, STATUS, PREV_RUN_ID)
+    VALUES (@PER_ID, @NEXT_RUN_NO, 1, GETDATE(), @CALC_BY, 1, @PREV_RUN_ID);
+
+    SET @NEW_RUN_ID = SCOPE_IDENTITY();
+
+    CREATE TABLE #AdvResult (
+        EMP_ID             INT, PCODE NVARCHAR(50), FULL_NAME NVARCHAR(150),
+        RAW_BALANCE        BIGINT, MANUAL_EXCL BIGINT, ADVANCE_DEDUCTION  BIGINT
+    );
+
+    IF @ADV_ENABLED = 1
+    BEGIN
+        INSERT INTO #AdvResult (EMP_ID, PCODE, FULL_NAME, RAW_BALANCE, MANUAL_EXCL, ADVANCE_DEDUCTION)
+        EXEC SP_PAY2_GET_ADVANCES
+            @PERIOD_DATE = @PERIOD_DATE,
+            @PAYROLL_N_S = @PAYROLL_N_S,
+            @WS_ID       = @WS_ID;
+    END;
+
+    -- گام ۳ — حلقه روی پرسنل فعال کارگاه
+    DECLARE
+        @EMP_ID INT, @IS_MANAGER BIT, @INS_TYPE TINYINT,
+        @TAX_EXEMPT_FLAG BIT, @REGION_DEP TINYINT, @ACC_T NVARCHAR(50); 
+
+    DECLARE cur_emp CURSOR LOCAL FAST_FORWARD FOR
+        SELECT E.EMP_ID, E.IS_MANAGER, E.INS_TYPE, E.TAX_EXEMPT, E.REGION_DEPRIVATION, E.ACC_T
+        FROM PAY2_EMPLOYEE E
+        WHERE E.WS_ID = @WS_ID AND E.IS_ACTIVE = 1
+          AND EXISTS (SELECT 1 FROM PAY2_ATTENDANCE A WHERE A.PER_ID = @PER_ID AND A.EMP_ID = E.EMP_ID);
+
+    OPEN cur_emp;
+    FETCH NEXT FROM cur_emp INTO @EMP_ID, @IS_MANAGER, @INS_TYPE, @TAX_EXEMPT_FLAG, @REGION_DEP, @ACC_T;
+
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        DECLARE
+            @WORK_DAYS DECIMAL(5,2)=0, @DAYS DECIMAL(5,2)=0, @DAYSB DECIMAL(5,2)=0,
+            @FRID_COUNT TINYINT=0, @TDAYS DECIMAL(5,2)=0, @OT_NORMAL_H DECIMAL(6,2)=0,
+            @OT_HOLIDAY_H DECIMAL(6,2)=0, @OT_ADMIN_H DECIMAL(6,2)=0, @LEAVE_DAYS DECIMAL(5,2)=0,
+            @PERF_AMOUNT BIGINT=0, @TRANSP_AMOUNT BIGINT=0, @KASR_OTHER BIGINT=0;
+
+        SELECT
+            @WORK_DAYS = ISNULL(WORK_DAYS,0), @DAYS = ISNULL(DAYS,0), @DAYSB = ISNULL(DAYSB,0),
+            @FRID_COUNT = ISNULL(FRID_COUNT,0), @TDAYS = ISNULL(TDAYS,0), @OT_NORMAL_H = ISNULL(OT_NORMAL_H,0),
+            @OT_HOLIDAY_H = ISNULL(OT_HOLIDAY_H,0), @OT_ADMIN_H = ISNULL(OT_ADMIN_H,0), @LEAVE_DAYS = ISNULL(LEAVE_DAYS,0),
+            @PERF_AMOUNT = ISNULL(PERF_AMOUNT,0), @TRANSP_AMOUNT = ISNULL(TRANSP_AMOUNT,0), @KASR_OTHER = ISNULL(KASR_OTHER,0)
+        FROM PAY2_ATTENDANCE WHERE PER_ID = @PER_ID AND EMP_ID = @EMP_ID;
+
+        CREATE TABLE #ItemCalc (
+            ITEM_ID INT, ITEM_CODE NVARCHAR(30), ITEM_TYPE TINYINT,
+            AMOUNT BIGINT, INS_SUBJECT BIT, TAX_SUBJECT BIT
+        );
+
+        -- گام ۴ — یافتن حکم معتبر
+        DECLARE @DEC_ID INT, @DEC_FROM BIGINT, @DEC_TO BIGINT;
+
+        DECLARE cur_dec CURSOR LOCAL FAST_FORWARD FOR
+            SELECT DEC_ID, EFF_FROM, ISNULL(EFF_TO, 99991231)
+            FROM PAY2_DECREE
+            WHERE EMP_ID = @EMP_ID AND IS_CONFIRMED = 1
+              AND EFF_FROM <= @PERIOD_DATE + 30   
+              AND (EFF_TO IS NULL OR EFF_TO >= @PERIOD_DATE)
+            ORDER BY EFF_FROM;
+
+        OPEN cur_dec;
+        FETCH NEXT FROM cur_dec INTO @DEC_ID, @DEC_FROM, @DEC_TO;
+
+        WHILE @@FETCH_STATUS = 0
+        BEGIN
+            -- گام ۵ — محاسبه هر آیتم حکم
+            DECLARE
+                @ITEM_ID INT, @ITEM_CODE NVARCHAR(30), @ITEM_TYPE TINYINT, @ITEM_AMOUNT BIGINT,
+                @ITEM_BASIS TINYINT, @ITEM_INS BIT, @ITEM_TAX BIT, @ITEM_PBD TINYINT,  
+                @OV_INS BIT, @OV_TAX BIT, @OV_BASIS TINYINT, @CALC_AMOUNT BIGINT = 0;
+
+            DECLARE cur_line CURSOR LOCAL FAST_FORWARD FOR
+                SELECT DL.ITEM_ID, ID.ITEM_CODE, ID.ITEM_TYPE, ISNULL(DL.AMOUNT, 0),
+                    ISNULL(DL.BASIS_OV, ID.CALC_BASIS), ISNULL(DL.INS_OV, ID.INS_SUBJECT), ISNULL(DL.TAX_OV, ID.TAX_SUBJECT), ID.PAY_BASE_DAYS
+                FROM PAY2_DECREE_LINE DL INNER JOIN PAY2_ITEM_DEF ID ON DL.ITEM_ID = ID.ITEM_ID
+                WHERE DL.DEC_ID = @DEC_ID AND ID.IS_ACTIVE = 1 AND ID.ITEM_CODE NOT IN ('INS_DED','TAX_DED','LOAN_DED','ADVANCE_DED')
+                ORDER BY ID.SORT_ORDER;
+
+            OPEN cur_line;
+            FETCH NEXT FROM cur_line INTO @ITEM_ID, @ITEM_CODE, @ITEM_TYPE, @ITEM_AMOUNT, @ITEM_BASIS, @ITEM_INS, @ITEM_TAX, @ITEM_PBD;
+
+            WHILE @@FETCH_STATUS = 0
+            BEGIN
+                -- v6.1: ریست متغیرها قبل از خواندن استثنا — اگر SELECT ردیفی برنگرداند،
+                -- مقادیر استثنای آیتم قبلی نباید به این آیتم نشت کند (باگ موروثی v6.0)
+                SELECT @OV_INS = NULL, @OV_TAX = NULL, @OV_BASIS = NULL;
+
+                SELECT TOP 1 @OV_INS = INS_OV, @OV_TAX = TAX_OV, @OV_BASIS = BASIS_OV
+                FROM PAY2_OVERRIDE WHERE EMP_ID = @EMP_ID AND ITEM_ID = @ITEM_ID
+                  AND VALID_FROM <= @PERIOD_DATE AND (VALID_TO IS NULL OR VALID_TO >= @PERIOD_DATE)
+                ORDER BY VALID_FROM DESC;
+
+                IF @OV_INS IS NOT NULL SET @ITEM_INS = @OV_INS;
+                IF @OV_TAX IS NOT NULL SET @ITEM_TAX = @OV_TAX;
+                IF @OV_BASIS IS NOT NULL SET @ITEM_BASIS = @OV_BASIS;
+
+                -- v6.1: مبنای ساعتی (3) — مبلغ ثبت‌شده در حکم، «نرخ هر ساعت» است
+                IF @ITEM_BASIS = 3
+                BEGIN
+                    SET @CALC_AMOUNT =
+                        CASE @ITEM_CODE
+                            WHEN 'OT_NORMAL'  THEN CAST(@ITEM_AMOUNT * @OT_NORMAL_H  AS BIGINT)
+                            WHEN 'OT_HOLIDAY' THEN CAST(@ITEM_AMOUNT * @OT_HOLIDAY_H AS BIGINT)
+                            WHEN 'OT_ADMIN'   THEN CAST(@ITEM_AMOUNT * @OT_ADMIN_H   AS BIGINT)
+                            -- سایر آیتم‌های ساعتی: نرخ ساعتی × (روز کارکرد × ساعت کاری روزانه)
+                            ELSE CAST(@ITEM_AMOUNT * (CASE @ITEM_PBD WHEN 1 THEN @DAYS ELSE @DAYSB END) * @OT_HOUR_BASE AS BIGINT)
+                        END;
+                END;
+                ELSE IF @ITEM_BASIS = 1 
+                BEGIN
+                    DECLARE @PAY_DAYS DECIMAL(5,2) = CASE @ITEM_PBD WHEN 1 THEN @DAYS ELSE @DAYSB END;
+
+                    IF @ITEM_CODE IN ('HOME','CHILDREN','GROCERY')
+                        SET @CALC_AMOUNT = CASE WHEN @PAY_DAYS >= 28 THEN @ITEM_AMOUNT ELSE CAST(@ITEM_AMOUNT * @PAY_DAYS / 30.0 AS BIGINT) END;
+                    ELSE IF @ITEM_CODE = 'NAHAR'
+                    BEGIN
+                        DECLARE @NAHAR_DAYS DECIMAL(5,2) = @DAYSB - @FRID_COUNT - @LEAVE_DAYS + @TDAYS;
+                        SET @CALC_AMOUNT = CASE WHEN @NAHAR_DAYS > 0 THEN CAST(@ITEM_AMOUNT * @NAHAR_DAYS AS BIGINT) ELSE CAST(@ITEM_AMOUNT * @DAYSB AS BIGINT) END;
+                    END;
+                    ELSE IF @ITEM_CODE = 'SHIFT'
+                    BEGIN
+                        IF @SHIFT_MODE = 'FIXED'
+                            -- حالت مبلغ ثابت: مانند سایر آیتم‌های روزانه با تناسب روز کارکرد
+                            SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2)) AS BIGINT);
+                        ELSE
+                        BEGIN
+                            -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
+                            -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
+                            DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
+                            SET @CALC_AMOUNT = CAST(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0 AS BIGINT);
+                        END;
+                    END;
+                    ELSE
+                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2)) AS BIGINT);
+                END;
+                ELSE 
+                    SET @CALC_AMOUNT = ISNULL(@ITEM_AMOUNT, 0);
+
+                INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
+                VALUES (@ITEM_ID, @ITEM_CODE, @ITEM_TYPE, @CALC_AMOUNT, @ITEM_INS, @ITEM_TAX);
+
+                FETCH NEXT FROM cur_line INTO @ITEM_ID, @ITEM_CODE, @ITEM_TYPE, @ITEM_AMOUNT, @ITEM_BASIS, @ITEM_INS, @ITEM_TAX, @ITEM_PBD;
+            END;
+            CLOSE cur_line; DEALLOCATE cur_line;
+
+            FETCH NEXT FROM cur_dec INTO @DEC_ID, @DEC_FROM, @DEC_TO;
+        END;
+        CLOSE cur_dec; DEALLOCATE cur_dec;
+
+        -- گام ۶ — افزودن آیتم‌های متغیر
+        -- v6.1: اگر آیتم اضافه‌کار به صورت صریح در حکم تعریف شده باشد (مثلاً با نرخ ساعتی)،
+        -- محاسبه خودکار آن از روی حقوق پایه انجام نمی‌شود تا دوبار منظور نگردد
+        DECLARE @BASE_SAL_DAILY BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL' OR ITEM_CODE = 'BASE_SAL_B'), 0);
+
+        IF @OT_NORMAL_H > 0 AND NOT EXISTS (SELECT 1 FROM #ItemCalc WHERE ITEM_CODE = 'OT_NORMAL')
+        BEGIN
+            DECLARE @OT_NORMAL_AMT BIGINT = ISNULL(CAST(@BASE_SAL_DAILY / (@MONTH_DAYS * @OT_HOUR_BASE) * @OT_NORMAL_H * @OT_NORMAL_MULT AS BIGINT), 0);
+            INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
+            SELECT ITEM_ID, 'OT_NORMAL', 2, @OT_NORMAL_AMT, INS_SUBJECT, TAX_SUBJECT FROM PAY2_ITEM_DEF WHERE ITEM_CODE = 'OT_NORMAL';
+        END;
+
+        IF @OT_HOLIDAY_H > 0 AND NOT EXISTS (SELECT 1 FROM #ItemCalc WHERE ITEM_CODE = 'OT_HOLIDAY')
+        BEGIN
+            DECLARE @OT_HOLIDAY_AMT BIGINT = ISNULL(CAST(@BASE_SAL_DAILY / (@MONTH_DAYS * @OT_HOUR_BASE) * @OT_HOLIDAY_H * @OT_HOLIDAY_MULT AS BIGINT), 0);
+            INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
+            SELECT ITEM_ID, 'OT_HOLIDAY', 2, @OT_HOLIDAY_AMT, INS_SUBJECT, TAX_SUBJECT FROM PAY2_ITEM_DEF WHERE ITEM_CODE = 'OT_HOLIDAY';
+        END;
+
+        IF @OT_ADMIN_H > 0 AND NOT EXISTS (SELECT 1 FROM #ItemCalc WHERE ITEM_CODE = 'OT_ADMIN')
+        BEGIN
+            DECLARE @OT_ADMIN_AMT BIGINT = ISNULL(CAST(@BASE_SAL_DAILY / (@MONTH_DAYS * @OT_HOUR_BASE) * @OT_ADMIN_H * @OT_NORMAL_MULT AS BIGINT), 0);
+            INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
+            SELECT ITEM_ID, 'OT_ADMIN', 2, @OT_ADMIN_AMT, INS_SUBJECT, TAX_SUBJECT FROM PAY2_ITEM_DEF WHERE ITEM_CODE = 'OT_ADMIN';
+        END;
+
+        IF @PERF_AMOUNT > 0
+            INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
+            SELECT ITEM_ID, 'PERF_BONUS', 2, @PERF_AMOUNT, INS_SUBJECT, TAX_SUBJECT FROM PAY2_ITEM_DEF WHERE ITEM_CODE = 'PERF_BONUS';
+
+        IF @TRANSP_AMOUNT > 0
+            INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
+            SELECT ITEM_ID, 'TRANSP', 2, @TRANSP_AMOUNT, INS_SUBJECT, TAX_SUBJECT FROM PAY2_ITEM_DEF WHERE ITEM_CODE = 'TRANSP';
+
+        INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
+        SELECT AV.ITEM_ID, ID.ITEM_CODE, ID.ITEM_TYPE, AV.VALUE, ID.INS_SUBJECT, ID.TAX_SUBJECT
+        FROM PAY2_ATT_VALUE AV INNER JOIN PAY2_ITEM_DEF ID ON AV.ITEM_ID = ID.ITEM_ID
+        WHERE AV.PER_ID = @PER_ID AND AV.EMP_ID = @EMP_ID AND AV.VALUE <> 0
+          AND NOT EXISTS (SELECT 1 FROM #ItemCalc X WHERE X.ITEM_ID = AV.ITEM_ID);
+
+        -- گام ۷ — محاسبه بیمه
+        DECLARE @GROSS_PAY BIGINT=0, @INS_BASE BIGINT=0, @INS_WORKER BIGINT=0, @INS_EMPLOYER BIGINT=0;
+
+        SELECT @GROSS_PAY = ISNULL(SUM(AMOUNT), 0) FROM #ItemCalc WHERE ITEM_TYPE IN (1, 2);
+        SELECT @INS_BASE = ISNULL(SUM(AMOUNT), 0) FROM #ItemCalc WHERE INS_SUBJECT = 1 AND ITEM_TYPE IN (1, 2);
+
+        IF @INS_CEILING_APPLY = 1 AND @INS_TYPE <> 3
+            SET @INS_BASE = CASE WHEN @INS_BASE > @INS_CEILING THEN @INS_CEILING ELSE @INS_BASE END;
+
+        IF @INS_TYPE = 3 
+        BEGIN
+            SET @INS_BASE = 0; SET @INS_WORKER = 0; SET @INS_EMPLOYER = 0;
+        END;
+        ELSE
+        BEGIN
+            SET @INS_WORKER = ISNULL(CAST(@INS_BASE * @INS_WORKER_RATE AS BIGINT), 0);
+            
+            DECLARE @EMP_IS_JANBAZ BIT = ISNULL((SELECT IS_JANBAZ FROM PAY2_EMPLOYEE WHERE EMP_ID = @EMP_ID), 0);
+            DECLARE @JANBAZ_RATE   DECIMAL(6,4) = ISNULL(CAST((SELECT CFG_VALUE FROM PAY2_CONFIG WHERE CFG_KEY='INS_JANBAZ_RATE') AS DECIMAL(6,4)), 0.18);
+
+            IF @EMP_IS_JANBAZ = 1
+                SET @INS_EMPLOYER = ISNULL(CAST(@INS_BASE * @JANBAZ_RATE AS BIGINT), 0); 
+            ELSE
+                SET @INS_EMPLOYER = ISNULL(CAST(@INS_BASE * (@INS_EMPLOYER_RATE + CASE WHEN ISNULL(@IS_MANAGER,0)=0 THEN @INS_UNEMP_RATE ELSE 0 END) AS BIGINT), 0);
+        END;
+
+        -- گام ۸ — محاسبه مالیات
+        DECLARE @TAX_BASE BIGINT=0, @TAX_AMOUNT BIGINT=0;
+
+        IF @TAX_EXEMPT_FLAG = 1
+        BEGIN
+            SET @TAX_BASE = 0; SET @TAX_AMOUNT = 0;
+        END;
+        ELSE
+        BEGIN
+            SELECT @TAX_BASE = ISNULL(SUM(AMOUNT), 0) FROM #ItemCalc WHERE TAX_SUBJECT = 1 AND ITEM_TYPE IN (1, 2);
+            IF @TAX_DEDUCT_INS = 1 SET @TAX_BASE = @TAX_BASE - @INS_WORKER;
+            SET @TAX_BASE = CASE WHEN @TAX_BASE > @TAX_EXEMPT THEN @TAX_BASE - @TAX_EXEMPT ELSE 0 END;
+            IF @TAX_DEP_APPLY = 1 AND @REGION_DEP > 0 SET @TAX_BASE = CAST(@TAX_BASE * (1.0 - @REGION_DEP / 100.0) AS BIGINT);
+            SET @TAX_AMOUNT = ISNULL([dbo].[FN_PAY2_CALC_TAX](@TAX_BASE * 12, @TAX_YEAR) / 12, 0);
+            IF @TAX_AMOUNT < 0 SET @TAX_AMOUNT = 0;
+        END;
+
+        -- گام ۹ — مساعده هوشمند
+        DECLARE @ADVANCE_DED BIGINT = 0;
+        IF @ADV_ENABLED = 1
+            SELECT @ADVANCE_DED = ISNULL(ADVANCE_DEDUCTION, 0) FROM #AdvResult WHERE EMP_ID = @EMP_ID;
+
+        -- گام ۱۰ — کسر وام خودکار
+        DECLARE @LOAN_DED BIGINT = 0;
+        SELECT @LOAN_DED = ISNULL(SUM(LS.AMOUNT), 0) FROM PAY2_LOAN_SCHED LS INNER JOIN PAY2_LOAN L ON LS.LOAN_ID = L.LOAN_ID
+        WHERE L.EMP_ID = @EMP_ID AND L.IS_ACTIVE = 1 AND LS.DUE_PERIOD = @PERIOD_DATE AND LS.RUN_ID IS NULL;
+
+        DECLARE @OTHER_DED BIGINT = ISNULL(@KASR_OTHER, 0);
+
+        -- گام ۱۱ — محاسبه خالص
+        DECLARE @TOTAL_DED BIGINT = @INS_WORKER + @TAX_AMOUNT + @LOAN_DED + @ADVANCE_DED + @OTHER_DED;
+        DECLARE @NET_PAY BIGINT = @GROSS_PAY - @TOTAL_DED;
+
+        IF @ROUND_MODE > 1
+            SET @NET_PAY = ISNULL(ROUND(@NET_PAY / CAST(@ROUND_MODE AS FLOAT), 0) * @ROUND_MODE, 0);
+
+        -- گام ۱۲ — ذخیره نتایج
+        DECLARE @LEAVE_BAL_DAYS DECIMAL(5,2) = NULL;
+        SELECT @LEAVE_BAL_DAYS = CAST(BALANCE_MIN AS DECIMAL(10,2)) / 440.0 FROM PAY2_LEAVE_BAL WHERE EMP_ID = @EMP_ID AND YEAR = @PERIOD_DATE / 10000;
+
+        DECLARE @LOAN_BAL BIGINT = NULL;
+        SELECT @LOAN_BAL = ISNULL(SUM(BALANCE), 0) FROM V_PAY2_LOAN_BALANCE WHERE EMP_ID = @EMP_ID;
+
+        INSERT INTO PAY2_RUN_LINE (
+            RUN_ID, EMP_ID, WORK_DAYS, GROSS_PAY, INS_BASE, INS_WORKER, INS_EMPLOYER, TAX_BASE, TAX_AMOUNT,
+            LOAN_DED, ADVANCE_DED, OTHER_DED, TOTAL_DED, NET_PAY, LEAVE_BAL_DAYS, LOAN_BALANCE, ADVANCE_BALANCE_SNAP
+        ) VALUES (
+            @NEW_RUN_ID, @EMP_ID, @DAYSB, @GROSS_PAY, @INS_BASE, @INS_WORKER, @INS_EMPLOYER, @TAX_BASE, @TAX_AMOUNT,
+            @LOAN_DED, @ADVANCE_DED, @OTHER_DED, @TOTAL_DED, @NET_PAY, @LEAVE_BAL_DAYS, @LOAN_BAL, @ADVANCE_DED
+        );
+
+        INSERT INTO PAY2_RUN_DETAIL (RUN_ID, EMP_ID, ITEM_ID, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
+        SELECT @NEW_RUN_ID, @EMP_ID, ITEM_ID, ISNULL(AMOUNT,0), ISNULL(INS_SUBJECT,0), ISNULL(TAX_SUBJECT,0) FROM #ItemCalc;
+
+        DECLARE @INS_DED_ID  INT = (SELECT ITEM_ID FROM PAY2_ITEM_DEF WHERE ITEM_CODE='INS_DED');
+        DECLARE @TAX_DED_ID  INT = (SELECT ITEM_ID FROM PAY2_ITEM_DEF WHERE ITEM_CODE='TAX_DED');
+        DECLARE @LOAN_DED_ID INT = (SELECT ITEM_ID FROM PAY2_ITEM_DEF WHERE ITEM_CODE='LOAN_DED');
+        DECLARE @ADV_DED_ID  INT = (SELECT ITEM_ID FROM PAY2_ITEM_DEF WHERE ITEM_CODE='ADVANCE_DED');
+
+        -- 🚀 رفع باگ T-SQL 213: افزودن نام ستون‌ها در INSERT VALUES 🚀
+        IF @INS_WORKER  > 0 INSERT INTO PAY2_RUN_DETAIL (RUN_ID, EMP_ID, ITEM_ID, AMOUNT, INS_SUBJECT, TAX_SUBJECT) VALUES (@NEW_RUN_ID,@EMP_ID,@INS_DED_ID, @INS_WORKER, 0,0);
+        IF @TAX_AMOUNT  > 0 INSERT INTO PAY2_RUN_DETAIL (RUN_ID, EMP_ID, ITEM_ID, AMOUNT, INS_SUBJECT, TAX_SUBJECT) VALUES (@NEW_RUN_ID,@EMP_ID,@TAX_DED_ID, @TAX_AMOUNT, 0,0);
+        IF @LOAN_DED    > 0 INSERT INTO PAY2_RUN_DETAIL (RUN_ID, EMP_ID, ITEM_ID, AMOUNT, INS_SUBJECT, TAX_SUBJECT) VALUES (@NEW_RUN_ID,@EMP_ID,@LOAN_DED_ID,@LOAN_DED,   0,0);
+        IF @ADVANCE_DED > 0 INSERT INTO PAY2_RUN_DETAIL (RUN_ID, EMP_ID, ITEM_ID, AMOUNT, INS_SUBJECT, TAX_SUBJECT) VALUES (@NEW_RUN_ID,@EMP_ID,@ADV_DED_ID, @ADVANCE_DED,0,0);
+
+        UPDATE PAY2_LOAN_SCHED SET RUN_ID = @NEW_RUN_ID, PAID_AT = GETDATE()
+        WHERE DUE_PERIOD = @PERIOD_DATE AND RUN_ID IS NULL AND LOAN_ID IN (SELECT LOAN_ID FROM PAY2_LOAN WHERE EMP_ID=@EMP_ID AND IS_ACTIVE=1);
+
+        UPDATE PAY2_LOAN SET PAID_INST = PAID_INST + (SELECT COUNT(*) FROM PAY2_LOAN_SCHED WHERE LOAN_ID=PAY2_LOAN.LOAN_ID AND DUE_PERIOD=@PERIOD_DATE AND RUN_ID=@NEW_RUN_ID)
+        WHERE EMP_ID=@EMP_ID AND IS_ACTIVE=1;
+
+        DECLARE @LEAVE_MIN_USED INT = CAST(@LEAVE_DAYS * 440 AS INT);
+        IF @LEAVE_MIN_USED > 0
+        BEGIN
+            UPDATE PAY2_LEAVE_BAL SET USED_MIN = USED_MIN + @LEAVE_MIN_USED, UPDATED_AT = GETDATE()
+            WHERE EMP_ID = @EMP_ID AND YEAR = @PERIOD_DATE / 10000;
+        END;
+
+        DROP TABLE #ItemCalc;
+
+        FETCH NEXT FROM cur_emp INTO @EMP_ID, @IS_MANAGER, @INS_TYPE, @TAX_EXEMPT_FLAG, @REGION_DEP, @ACC_T;
+    END;
+
+    CLOSE cur_emp; DEALLOCATE cur_emp;
+    DROP TABLE #AdvResult;
+
+    UPDATE PAY2_PERIOD SET STATUS = 3 WHERE PER_ID = @PER_ID;
+
+END;
+GO

--- a/Server/Scripts/007_Pay2_HourlyLeaveType.sql
+++ b/Server/Scripts/007_Pay2_HourlyLeaveType.sql
@@ -1,0 +1,24 @@
+-- ============================================================================
+-- پشتیبانی از نوع مرخصی «ساعتی» (مقدار 6) در جدول PAY2_LEAVE
+--
+-- انواع مرخصی:
+--   1=استحقاقی  2=استعلاجی  3=بدون حقوق  4=زایمان  5=مأموریت  6=ساعتی (جدید)
+--
+-- اگر CHECK CONSTRAINT روی LEV_TYPE مقدار 6 را مجاز نمی‌داند، حذف می‌شود.
+-- سقف مرخصی ساعتی (3 ساعت و 20 دقیقه) در سمت سرور (Pay2EmployeesController)
+-- و سمت کلاینت اعتبارسنجی می‌شود.
+-- ============================================================================
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql + N'ALTER TABLE ' + QUOTENAME(OBJECT_SCHEMA_NAME(cc.parent_object_id))
+            + N'.' + QUOTENAME(OBJECT_NAME(cc.parent_object_id))
+            + N' DROP CONSTRAINT ' + QUOTENAME(cc.name) + N';' + CHAR(10)
+FROM sys.check_constraints cc
+WHERE OBJECT_NAME(cc.parent_object_id) = 'PAY2_LEAVE'
+  AND cc.definition LIKE '%LEV_TYPE%'
+  AND cc.definition NOT LIKE '%(6)%';
+
+IF LEN(@sql) > 0
+    EXEC sp_executesql @sql;
+GO

--- a/Shared/Models/Salary/Pay2AttendanceModels.cs
+++ b/Shared/Models/Salary/Pay2AttendanceModels.cs
@@ -54,9 +54,42 @@ namespace Safir.Shared.Models.Salary
         public string DAYS_KHADAMAT_STR { get => DAYS_KHADAMAT.ToString("0.##"); set { _ = decimal.TryParse(value?.Replace("/", "."), out decimal v); if (DAYS_KHADAMAT != v) { DAYS_KHADAMAT = v; IsDirty = true; } } }
         public string DAYS_FOROSH_STR { get => DAYS_FOROSH.ToString("0.##"); set { _ = decimal.TryParse(value?.Replace("/", "."), out decimal v); if (DAYS_FOROSH != v) { DAYS_FOROSH = v; IsDirty = true; } } }
 
-        public string OT_NORMAL_H_STR { get => OT_NORMAL_H.ToString("0.##"); set { _ = decimal.TryParse(value?.Replace("/", "."), out decimal v); if (OT_NORMAL_H != v) { OT_NORMAL_H = v; IsDirty = true; } } }
-        public string OT_HOLIDAY_H_STR { get => OT_HOLIDAY_H.ToString("0.##"); set { _ = decimal.TryParse(value?.Replace("/", "."), out decimal v); if (OT_HOLIDAY_H != v) { OT_HOLIDAY_H = v; IsDirty = true; } } }
-        public string OT_ADMIN_H_STR { get => OT_ADMIN_H.ToString("0.##"); set { _ = decimal.TryParse(value?.Replace("/", "."), out decimal v); if (OT_ADMIN_H != v) { OT_ADMIN_H = v; IsDirty = true; } } }
+        // اضافه‌کاری: پشتیبانی از فرمت «ساعت:دقیقه» (مثال 32:35) و عدد اعشاری (مثال 32.5) مانند نرم‌افزار قبلی
+        public string OT_NORMAL_H_STR { get => FormatHours(OT_NORMAL_H); set { decimal v = ParseHours(value); if (OT_NORMAL_H != v) { OT_NORMAL_H = v; IsDirty = true; } } }
+        public string OT_HOLIDAY_H_STR { get => FormatHours(OT_HOLIDAY_H); set { decimal v = ParseHours(value); if (OT_HOLIDAY_H != v) { OT_HOLIDAY_H = v; IsDirty = true; } } }
+        public string OT_ADMIN_H_STR { get => FormatHours(OT_ADMIN_H); set { decimal v = ParseHours(value); if (OT_ADMIN_H != v) { OT_ADMIN_H = v; IsDirty = true; } } }
+
+        // تبدیل «32:35» به 32.58 ساعت (دقیقه ÷ 60) و پذیرش ورودی اعشاری «32.5» یا «32/5»
+        public static decimal ParseHours(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return 0m;
+
+            value = value.Trim();
+
+            if (value.Contains(':'))
+            {
+                var parts = value.Split(':');
+                _ = decimal.TryParse(parts[0], out decimal hours);
+                decimal minutes = 0m;
+                if (parts.Length > 1) _ = decimal.TryParse(parts[1], out minutes);
+                return hours + (minutes / 60m);
+            }
+
+            _ = decimal.TryParse(value.Replace("/", "."), System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture, out decimal v);
+            return v;
+        }
+
+        // نمایش ساعت اعشاری به صورت «ساعت:دقیقه» — اعداد صحیح بدون تغییر نمایش داده می‌شوند
+        public static string FormatHours(decimal hours)
+        {
+            if (hours == decimal.Truncate(hours)) return hours.ToString("0");
+
+            int h = (int)decimal.Truncate(hours);
+            int m = (int)Math.Round((hours - h) * 60m, MidpointRounding.AwayFromZero);
+            if (m >= 60) { h++; m -= 60; }
+            return $"{h}:{m:D2}";
+        }
 
         public string LEAVE_DAYS_STR { get => LEAVE_DAYS.ToString("0.##"); set { _ = decimal.TryParse(value?.Replace("/", "."), out decimal v); if (LEAVE_DAYS != v) { LEAVE_DAYS = v; IsDirty = true; } } }
         public string ABSENT_DAYS_STR { get => ABSENT_DAYS.ToString("0.##"); set { _ = decimal.TryParse(value?.Replace("/", "."), out decimal v); if (ABSENT_DAYS != v) { ABSENT_DAYS = v; IsDirty = true; } } }

--- a/Shared/Models/Salary/Pay2EmployeeModels.cs
+++ b/Shared/Models/Salary/Pay2EmployeeModels.cs
@@ -84,15 +84,22 @@
             set => TAX_OV = value == 3 ? (bool?)null : (value == 1);
         }
 
+        // 👇 شناسه 9 برای "طبق تعریف پایه" (null) — مقادیر 1=روزانه، 2=ماهیانه، 3=ساعتی مستقیماً ذخیره می‌شوند
         public int BasisCombo
         {
-            get => BASIS_OV == null ? 3 : (BASIS_OV == 1 ? 1 : 2);
-            set => BASIS_OV = value == 3 ? (byte?)null : (byte)value;
+            get => BASIS_OV == null ? 9 : BASIS_OV.Value;
+            set => BASIS_OV = value == 9 ? (byte?)null : (byte)value;
         }
 
         public string InsText => INS_OV == null ? "پایه" : (INS_OV == true ? "مشمول" : "معاف");
         public string TaxText => TAX_OV == null ? "پایه" : (TAX_OV == true ? "مشمول" : "معاف");
-        public string BasisText => BASIS_OV == null ? "پایه" : (BASIS_OV == 1 ? "روزانه" : "ماهیانه");
+        public string BasisText => BASIS_OV switch
+        {
+            null => "پایه",
+            1 => "روزانه",
+            3 => "ساعتی",
+            _ => "ماهیانه"
+        };
     }
 
     public class Pay2LeaveDto
@@ -113,6 +120,10 @@
         public int? REFER_TO { get; set; }
         public byte STATUS { get; set; } = 1;
 
+        // نوع مرخصی ساعتی + سقف مجاز آن (۳ ساعت و ۲۰ دقیقه = ۲۰۰ دقیقه)
+        public const byte HOURLY_TYPE = 6;
+        public const int HOURLY_MAX_MINUTES = 200;
+
         // --- پراپرتی‌های محاسباتی و نمایشی ---
         public int TotalMinutes => (REQ_DAYS * 440) + (REQ_HOURS * 60) + REQ_MINUTES;
 
@@ -123,6 +134,7 @@
             3 => "بدون حقوق",
             4 => "زایمان",
             5 => "مأموریت",
+            6 => "ساعتی",
             _ => "نامشخص"
         };
 
@@ -229,16 +241,23 @@
             set => TAX_OV = value == 3 ? (bool?)null : (value == 1);
         }
 
+        // 👇 شناسه 9 برای "بدون تغییر" (null) — مقادیر 1=روزانه، 2=ماهیانه، 3=ساعتی مستقیماً ذخیره می‌شوند
         public int BasisCombo
         {
-            get => BASIS_OV == null ? 3 : (BASIS_OV == 1 ? 1 : 2);
-            set => BASIS_OV = value == 3 ? (byte?)null : (byte)value;
+            get => BASIS_OV == null ? 9 : BASIS_OV.Value;
+            set => BASIS_OV = value == 9 ? (byte?)null : (byte)value;
         }
 
         // --- برای نمایش در جدول گرید ---
         public string InsText => INS_OV == null ? "بدون تغییر" : (INS_OV == true ? "مشمول" : "معاف");
         public string TaxText => TAX_OV == null ? "بدون تغییر" : (TAX_OV == true ? "مشمول" : "معاف");
-        public string BasisText => BASIS_OV == null ? "بدون تغییر" : (BASIS_OV == 1 ? "روزانه" : "ماهیانه");
+        public string BasisText => BASIS_OV switch
+        {
+            null => "بدون تغییر",
+            1 => "روزانه",
+            3 => "ساعتی",
+            _ => "ماهیانه"
+        };
     }
     public class Pay2AdvanceExclDto
     {
@@ -323,11 +342,18 @@
         // پراپرتی‌های کمکی برای بایندینگ به کامبوباکسِ Pay2Select در UI
         public int InsCombo { get => INS_OV == null ? 3 : (INS_OV == true ? 1 : 2); set => INS_OV = value == 3 ? (bool?)null : (value == 1); }
         public int TaxCombo { get => TAX_OV == null ? 3 : (TAX_OV == true ? 1 : 2); set => TAX_OV = value == 3 ? (bool?)null : (value == 1); }
-        public int BasisCombo { get => BASIS_OV == null ? 3 : (BASIS_OV == 1 ? 1 : 2); set => BASIS_OV = value == 3 ? (byte?)null : (byte)value; }
+        // 👇 شناسه 9 برای "طبق تعریف پایه" (null) — مقادیر 1=روزانه، 2=ماهیانه، 3=ساعتی مستقیماً ذخیره می‌شوند
+        public int BasisCombo { get => BASIS_OV == null ? 9 : BASIS_OV.Value; set => BASIS_OV = value == 9 ? (byte?)null : (byte)value; }
 
         public string InsText => INS_OV == null ? "پایه" : (INS_OV == true ? "مشمول" : "معاف");
         public string TaxText => TAX_OV == null ? "پایه" : (TAX_OV == true ? "مشمول" : "معاف");
-        public string BasisText => BASIS_OV == null ? "پایه" : (BASIS_OV == 1 ? "روزانه" : "ماهیانه");
+        public string BasisText => BASIS_OV switch
+        {
+            null => "پایه",
+            1 => "روزانه",
+            3 => "ساعتی",
+            _ => "ماهیانه"
+        };
     }
     public class Pay2JobDto
     {

--- a/Shared/Models/Salary/Pay2ItemDefModels.cs
+++ b/Shared/Models/Salary/Pay2ItemDefModels.cs
@@ -28,6 +28,11 @@
             _ => "نامشخص"
         };
 
-        public string CalcBasisText => CALC_BASIS == 1 ? "روزانه" : "ماهیانه";
+        public string CalcBasisText => CALC_BASIS switch
+        {
+            1 => "روزانه",
+            3 => "ساعتی",
+            _ => "ماهیانه"
+        };
     }
 }


### PR DESCRIPTION
# خلاصه

این PR جایگزین تمیز #64 است (یک کامیت واحد شامل وضعیت نهایی + اصلاحات بازبینی عمیق).

## شش درخواست کاربری

1. **مبنای محاسبه «ساعتی» (مقدار ۳)** برای آیتم‌های حکم — اضافه‌کار عادی/تعطیل/اداری با نرخ ساعتی صریح در حکم: `نرخ × ساعات کارکرد همان ستون`. گزینه «ساعتی» در تعریف آیتم، اقلام حکم، استثناها و قالب‌ها اضافه شد (شناسه «طبق تعریف پایه» در کمبوها از ۳ به ۹ منتقل شد — فقط UI، داده‌ای جابه‌جا نمی‌شود).
2. **حق شیفت درصدی از حقوق پایه ماهیانه** — برای آیتم SHIFT در حالت `SHIFT_MODE=PCT`، فیلد مبلغ همان «درصد» است (مانند حکم قبلی) با پیش‌نمایش زنده مبلغ ریالی. برای سایر آیتم‌های ماهیانه، کمک‌محاسبه «درصد از حقوق ماهیانه» مبلغ ریالی را پر می‌کند.
3. **مرخصی ساعتی (نوع ۶)** با سقف **۳:۲۰** (۲۰۰ دقیقه) — اعتبارسنجی در کلاینت و سرور؛ فیلد روز غیرفعال؛ همیشه تک‌روزه.
4. **اضافه‌کاری ساعت:دقیقه** — ورود `32:35` یا `32.5` در گرید کارکرد (حالت جدید `HoursMinutes` در Pay2NumericInput + گارد JS). ذخیره به‌صورت ساعت اعشاری در `DECIMAL(6,2)` موجود؛ رفت‌وبرگشت نمایش برای تمام دقیقه‌های ۰–۵۹ دقیق است.
5. **دریافت کامل شغل‌ها** — حذف `TOP 50` از lookup مشاغل (علت دیده‌نشدن «کارمند اداری») + جستجو روی کد شغل.
6. **Enter به‌جای موس** — در همه فرم‌های ماژول حقوق و دستمزد، Enter فوکوس را به فیلد بعدی می‌برد (`pay2-enter-nav.js`؛ فقط روی کلاس‌های ورودی Pay2، بدون اثر روی سایر بخش‌ها).

## اسکریپت دیتابیس (اجرای دستی لازم)

`Server/Scripts/006_Pay2_HourlyCalcBasis.sql` — نسخه کامل **SP_PAY2_CALC_RUN v6.1** (CREATE OR ALTER؛ اجرای چندباره بی‌خطر). می‌توانید مستقیم اجرا کنید یا جایگزین بدنه SP در `SalaryScript` (مستر کارکت) کنید:
- مبنای ساعتی (۳) در گام ۵
- جلوگیری از دوبارمحاسبه اضافه‌کار وقتی آیتم صریحاً در حکم است
- اصلاح فرمول SHIFT به «درصدِ حقوق پایه ماهیانه» + پشتیبانی `SHIFT_MODE=FIXED`
- **رفع باگ موروثی v6.0**: نشت متغیرهای استثنا (PAY2_OVERRIDE) از یک آیتم به آیتم‌های بعدی همان حکم + `ORDER BY` برای `TOP 1`
- باز کردن قید `CK_CALC_BASIS` برای مقدار ۳

`Server/Scripts/007_Pay2_HourlyLeaveType.sql` — دفاعی برای نوع مرخصی ۶.

## ⚠️ نکات مهاجرت / تصمیم‌ها

- پس از اجرای 006، مقدار آیتم SHIFT در احکام موجود «درصد از حقوق ماهیانه» تفسیر می‌شود — مقادیر قبلی را بازبینی کنید.
- نرخ ساعتیِ حکم نرخ نهایی است؛ ضریب ۱.۴ روی آن اعمال نمی‌شود (اگر باید بشود، یک خط در SP تغییر می‌کند).

## تست

- بیلد کامل Solution بدون خطا (net8.0).
- بازبینی عمیق چندزاویه‌ای انجام و یافته‌های آن (نشت Override، تاریخ پایان مرخصی ساعتی، کش JS، ساده‌سازی‌ها) در همین PR اعمال شد.

https://claude.ai/code/session_01Jr9LtfbzwKtMwKAAq32ywG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jr9LtfbzwKtMwKAAq32ywG)_