### PR TITLE
feat: پشتیبانی از مقدار اعشاری برای فیلد حق شیفت (PCT)

### DIFF
--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
@@ -64,9 +64,11 @@
                             <label>@(IsShiftPctItem ? "درصد از حقوق پایه ماهیانه (٪) *" : "مبلغ در این حکم (ریال) *")</label>
                             <Pay2NumericInput @bind-Value="CurrentAmountStr" @bind-Value:after="OnAmountManuallyChanged"
                                               MaxLength="@(IsShiftPctItem ? 3 : 16)" Direction="ltr"
+                                              InputMode="@(IsShiftPctItem ? Pay2NumericInput.NumericInputMode.Percentage : Pay2NumericInput.NumericInputMode.None)"
+                                              MaxDecimalPlaces="@(IsShiftPctItem ? 2 : 0)"
                                               IsDigitGroupActive="@(!IsShiftPctItem)" ThreeTwoZero="@(!IsShiftPctItem)"
-                                              Placeholder="@(IsShiftPctItem ? "مثال: 10" : null)"
-                                              ToolTip="@(IsShiftPctItem ? "حق شیفت به صورت درصدی از حقوق پایه ماهیانه (نرخ روزانه × ۳۰) محاسبه می‌شود — مانند حکم قبلی فقط عدد درصد را وارد کنید" : null)"
+                                              Placeholder="@(IsShiftPctItem ? "مثال: 10.5" : null)"
+                                              ToolTip="@(IsShiftPctItem ? "حق شیفت به صورت درصدی از حقوق پایه ماهیانه (نرخ روزانه × ۳۰) محاسبه می‌شود — عدد درصد را وارد کنید (اعشار هم مجاز است)" : null)"
                                               Disabled="@IsDecreeConfirmed" />
                             @if (IsShiftPctItem && !string.IsNullOrWhiteSpace(ShiftHint))
                             {
@@ -300,7 +302,7 @@
     // محاسبه «حقوق پایه ماهیانه» این حکم از روی آیتم حقوق پایه
     // موتور محاسبه برای حق شیفت از BASE_SAL_B (حقوق روزانه رسمی) استفاده می‌کند؛
     // مبنای روزانه در ۳۰ ضرب می‌شود تا مبلغ ماهیانه به دست آید
-    long? GetMonthlyBaseSalary()
+    decimal? GetMonthlyBaseSalary()
     {
         var baseDef = FullItemDefs.FirstOrDefault(d => d.ITEM_CODE == "BASE_SAL_B")
                    ?? FullItemDefs.FirstOrDefault(d => d.ITEM_CODE == "BASE_SAL");
@@ -380,7 +382,10 @@
     {
         ShiftHint = null;
 
-        if (!long.TryParse(CurrentAmountStr?.Replace(",", ""), out long pct) || pct <= 0)
+        if (!decimal.TryParse(CurrentAmountStr?.Replace(",", ""),
+                System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out decimal pct) || pct <= 0)
             return;
 
         var (computed, hint) = CalcPercentOfMonthly(pct);
@@ -402,7 +407,9 @@
             BASIS_OV = item.BASIS_OV
         };
 
-        CurrentAmountStr = CurrentLine.AMOUNT.ToString();
+        CurrentAmountStr = IsShiftPctItem
+            ? CurrentLine.AMOUNT.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : CurrentLine.AMOUNT.ToString("0", System.Globalization.CultureInfo.InvariantCulture);
         CurrentPercentStr = null;
         PercentHint = null;
         ShiftHint = null;
@@ -419,7 +426,10 @@
             Snackbar.Add("انتخاب آیتم حقوقی الزامی است.", MudBlazor.Severity.Warning); return;
         }
 
-        long.TryParse(CurrentAmountStr?.Replace(",", ""), out long amt);
+        decimal.TryParse(CurrentAmountStr?.Replace(",", ""),
+            System.Globalization.NumberStyles.Number,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out decimal amt);
 
         CurrentLine.DEC_ID = DecreeId;
         CurrentLine.AMOUNT = amt;

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
@@ -1,6 +1,8 @@
 ﻿@using Safir.Shared.Models
 @using Safir.Shared.Models.Salary
 @inject Safir.Client.Services.Pay2EmployeeApiService EmployeeApi
+@inject Safir.Client.Services.Pay2ItemDefApiService ItemDefApi
+@inject Safir.Client.Services.Pay2SettingsApiService SettingsApi
 @inject ISnackbar Snackbar
 @inject MudBlazor.IDialogService DialogService
 
@@ -34,13 +36,19 @@
                         <Safir.Client.Pages.Salary.Tabs.Pay2Select TItem="LookupDto<int>" TValue="int"
                                                                    Items="ItemDefs"
                                                                    @bind-Value="CurrentLine.ITEM_ID"
+                                                                   @bind-Value:after="OnItemChanged"
                                                                    TextSelector="x => x.Name" ValueSelector="x => x.Id"
                                                                    Placeholder="— انتخاب کنید —" Clearable="false"
                                                                    Disabled="@IsEditing" />
                     </div>
                     <div class="form-field">
-                        <label>مبلغ پیش‌فرض (DEF_AMOUNT)</label>
-                        <Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="AmountStr" MaxLength="16" Direction="ltr" IsDigitGroupActive="true" ThreeTwoZero="true" />
+                        <label>@(IsShiftPctItem ? "درصد از حقوق پایه (٪)" : "مبلغ پیش‌فرض (DEF_AMOUNT)")</label>
+                        <Safir.Client.Pages.Salary.Tabs.Pay2NumericInput @bind-Value="AmountStr"
+                            MaxLength="@(IsShiftPctItem ? 3 : 16)" Direction="ltr"
+                            InputMode="@(IsShiftPctItem ? Pay2NumericInput.NumericInputMode.Percentage : Pay2NumericInput.NumericInputMode.None)"
+                            MaxDecimalPlaces="@(IsShiftPctItem ? 2 : 0)"
+                            IsDigitGroupActive="@(!IsShiftPctItem)" ThreeTwoZero="@(!IsShiftPctItem)"
+                            Placeholder="@(IsShiftPctItem ? "مثال: 7.5" : null)" />
                     </div>
                 </div>
 
@@ -105,7 +113,16 @@
                             {
                                 <tr style="background: @(CurrentLine.ITEM_ID == item.ITEM_ID ? "var(--p2-bg-hover)" : "transparent")">
                                     <td><b>@item.ITEM_NAME</b></td>
-                                    <td class="p2-text-mono p2-text-primary" style="text-align:center; font-weight:bold;">@item.DEF_AMOUNT.ToString("N0")</td>
+                                    <td class="p2-text-mono p2-text-primary" style="text-align:center; font-weight:bold;">
+                                        @if (IsShiftPctLine(item))
+                                        {
+                                            <span>@item.DEF_AMOUNT٪</span>
+                                        }
+                                        else
+                                        {
+                                            <span>@item.DEF_AMOUNT.ToString("N0")</span>
+                                        }
+                                    </td>
                                     <td style="text-align:center; color: var(--p2-text-muted);">@item.InsText</td>
                                     <td style="text-align:center; color: var(--p2-text-muted);">@item.TaxText</td>
                                     <td style="text-align:center; color: var(--p2-text-muted);">@item.BasisText</td>
@@ -134,14 +151,25 @@
 
     List<Pay2ItemTmplLineDto> Lines = new();
     List<LookupDto<int>> ItemDefs = new();
+    List<Pay2ItemDefDto> FullItemDefs = new();
     Pay2ItemTmplLineDto CurrentLine = new();
 
     string? AmountStr;
+    string _shiftMode = "PCT";
     bool IsSaving = false;
     bool IsEditing = false;
     int _lastProcessedId = -1;
     bool _isDataLoaded = false;
     bool _lastOpenState = false;
+
+    bool IsShiftPctItem => IsShiftPctLine(CurrentLine);
+
+    bool IsShiftPctLine(Pay2ItemTmplLineDto line)
+    {
+        if (string.Equals(_shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase)) return false;
+        var def = FullItemDefs.FirstOrDefault(d => d.ITEM_ID == line.ITEM_ID);
+        return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
+    }
 
     List<LookupDto<int>> OverrideOptions = new() { new(3, "طبق تعریف پایه"), new(1, "مشمول"), new(2, "معاف") };
     List<LookupDto<int>> BasisOptions = new() { new(9, "طبق تعریف پایه"), new(1, "روزانه"), new(2, "ماهیانه"), new(3, "ساعتی") };
@@ -166,8 +194,17 @@
     {
         try
         {
-            ItemDefs = await EmployeeApi.GetItemDefsLookupAsync();
-            Lines = await EmployeeApi.GetTemplateLinesAsync(MasterTemplateId);
+            var itemDefsTask = EmployeeApi.GetItemDefsLookupAsync();
+            var linesTask = EmployeeApi.GetTemplateLinesAsync(MasterTemplateId);
+            var fullDefsTask = ItemDefApi.GetItemDefsAsync();
+            var shiftModeTask = LoadShiftModeAsync();
+
+            await Task.WhenAll(itemDefsTask, linesTask, fullDefsTask, shiftModeTask);
+
+            ItemDefs = itemDefsTask.Result;
+            Lines = linesTask.Result;
+            FullItemDefs = fullDefsTask.Result;
+            _shiftMode = shiftModeTask.Result;
         }
         catch (Exception ex) { Console.WriteLine(ex.Message); }
         finally
@@ -177,11 +214,26 @@
         }
     }
 
+    async Task<string> LoadShiftModeAsync()
+    {
+        try
+        {
+            var configs = await SettingsApi.GetConfigsAsync();
+            return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
+        }
+        catch { return "PCT"; }
+    }
+
     void ResetForm()
     {
         CurrentLine = new Pay2ItemTmplLineDto();
         AmountStr = null;
         IsEditing = false;
+    }
+
+    void OnItemChanged()
+    {
+        AmountStr = null;
     }
 
     void EditLine(Pay2ItemTmplLineDto item)
@@ -196,7 +248,9 @@
             TAX_OV = item.TAX_OV,
             BASIS_OV = item.BASIS_OV
         };
-        AmountStr = CurrentLine.DEF_AMOUNT.ToString();
+        AmountStr = IsShiftPctItem
+            ? CurrentLine.DEF_AMOUNT.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : ((long)decimal.Truncate(CurrentLine.DEF_AMOUNT)).ToString();
         IsEditing = true;
     }
 
@@ -206,7 +260,10 @@
         {
             Snackbar.Add("انتخاب آیتم حقوقی الزامی است.", MudBlazor.Severity.Warning); return;
         }
-        long.TryParse(AmountStr?.Replace(",", ""), out long amt);
+        decimal.TryParse(AmountStr?.Replace(",", ""),
+            System.Globalization.NumberStyles.Number,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out decimal amt);
         CurrentLine.TMPL_ID = MasterTemplateId;
         CurrentLine.DEF_AMOUNT = amt;
         IsSaving = true;

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -315,6 +315,14 @@ namespace Safir.Server.Controllers
                     if (isConfirmed)
                         throw new InvalidOperationException("این حکم قفل (تأیید نهایی) شده است! برای افزودن یا تغییر مبالغ، باید ابتدا در صفحه قبل، تیک تایید این حکم را بردارید.");
 
+                    // اعتبارسنجی: مقدار اعشاری فقط برای آیتم حق شیفت درصدی مجاز است
+                    if (line.AMOUNT != Math.Truncate(line.AMOUNT))
+                    {
+                        bool isShiftPct = await IsShiftPctItemAsync(conn, tran, line.ITEM_ID);
+                        if (!isShiftPct)
+                            throw new InvalidOperationException("مبلغ اعشاری فقط برای آیتم «حق شیفت درصدی» مجاز است.");
+                    }
+
                     int count = await conn.QuerySingleAsync<int>(
                         "SELECT COUNT(1) FROM PAY2_DECREE_LINE WHERE DEC_ID=@DEC_ID AND ITEM_ID=@ITEM_ID",
                         new { line.DEC_ID, line.ITEM_ID }, tran);
@@ -1009,6 +1017,14 @@ namespace Safir.Server.Controllers
             {
                 await _db.ExecuteInTransactionAsync(async (conn, tran) =>
                 {
+                    // اعتبارسنجی: مقدار اعشاری فقط برای آیتم حق شیفت درصدی مجاز است
+                    if (line.DEF_AMOUNT != Math.Truncate(line.DEF_AMOUNT))
+                    {
+                        bool isShiftPct = await IsShiftPctItemAsync(conn, tran, line.ITEM_ID);
+                        if (!isShiftPct)
+                            throw new InvalidOperationException("مبلغ اعشاری فقط برای آیتم «حق شیفت درصدی» مجاز است.");
+                    }
+
                     int count = await conn.QuerySingleAsync<int>("SELECT COUNT(1) FROM PAY2_ITEM_TMPL_LINE WHERE TMPL_ID=@TMPL_ID AND ITEM_ID=@ITEM_ID", new { line.TMPL_ID, line.ITEM_ID }, tran);
 
                     if (count == 0)
@@ -1193,6 +1209,18 @@ namespace Safir.Server.Controllers
                 return Ok();
             }
             catch (Exception ex) { return BadRequest(ex.Message); }
+        }
+
+        private static async Task<bool> IsShiftPctItemAsync(IDbConnection conn, IDbTransaction tran, int itemId)
+        {
+            string? itemCode = await conn.QuerySingleOrDefaultAsync<string>(
+                "SELECT ITEM_CODE FROM PAY2_ITEM_DEF WHERE ITEM_ID = @itemId", new { itemId }, tran);
+            if (!string.Equals(itemCode, "SHIFT", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            string? shiftMode = await conn.QuerySingleOrDefaultAsync<string>(
+                "SELECT CFG_VALUE FROM PAY2_CONFIG WHERE CFG_KEY = 'SHIFT_MODE'", null, tran);
+            return !string.Equals(shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase);
         }
 
     }

--- a/Server/Info/PAY2_DDL_v6.sql
+++ b/Server/Info/PAY2_DDL_v6.sql
@@ -522,7 +522,7 @@ CREATE TABLE [dbo].[PAY2_ITEM_TMPL_LINE]
 (
     [TMPL_ID]   INT      NOT NULL,
     [ITEM_ID]   INT      NOT NULL,
-    [DEF_AMOUNT] BIGINT  NOT NULL CONSTRAINT DF_TL_AMT DEFAULT(0),
+    [DEF_AMOUNT] DECIMAL(18,2) NOT NULL CONSTRAINT DF_TL_AMT DEFAULT(0),
     [INS_OV]    BIT      NULL,                                               -- NULL=از تعریف آیتم
     [TAX_OV]    BIT      NULL,
     [BASIS_OV]  TINYINT  NULL,
@@ -576,7 +576,7 @@ CREATE TABLE [dbo].[PAY2_DECREE_LINE]
 (
     [DEC_ID]   INT      NOT NULL,
     [ITEM_ID]  INT      NOT NULL,
-    [AMOUNT]   BIGINT   NOT NULL CONSTRAINT DF_DL_AMT DEFAULT(0),
+    [AMOUNT]   DECIMAL(18,2) NOT NULL CONSTRAINT DF_DL_AMT DEFAULT(0),
     [INS_OV]   BIT      NULL,                                                -- NULL=از PAY2_ITEM_DEF
     [TAX_OV]   BIT      NULL,
     [BASIS_OV] TINYINT  NULL,

--- a/Server/Info/PAY2_Procedures_v6.sql
+++ b/Server/Info/PAY2_Procedures_v6.sql
@@ -177,7 +177,7 @@ BEGIN
         BEGIN
             -- گام ۵ — محاسبه هر آیتم حکم
             DECLARE
-                @ITEM_ID INT, @ITEM_CODE NVARCHAR(30), @ITEM_TYPE TINYINT, @ITEM_AMOUNT BIGINT,
+                @ITEM_ID INT, @ITEM_CODE NVARCHAR(30), @ITEM_TYPE TINYINT, @ITEM_AMOUNT DECIMAL(18,2),
                 @ITEM_BASIS TINYINT, @ITEM_INS BIT, @ITEM_TAX BIT, @ITEM_PBD TINYINT,  
                 @OV_INS BIT, @OV_TAX BIT, @OV_BASIS TINYINT, @CALC_AMOUNT BIGINT = 0;
 

--- a/Server/Info/ScriptSqly.cs
+++ b/Server/Info/ScriptSqly.cs
@@ -596,7 +596,7 @@ CREATE TABLE [dbo].[PAY2_ITEM_TMPL_LINE]
 (
     [TMPL_ID]   INT      NOT NULL,
     [ITEM_ID]   INT      NOT NULL,
-    [DEF_AMOUNT] BIGINT  NOT NULL CONSTRAINT DF_TL_AMT DEFAULT(0),
+    [DEF_AMOUNT] DECIMAL(18,2) NOT NULL CONSTRAINT DF_TL_AMT DEFAULT(0),
     [INS_OV]    BIT      NULL,                                               -- NULL=از تعریف آیتم
     [TAX_OV]    BIT      NULL,
     [BASIS_OV]  TINYINT  NULL,
@@ -657,7 +657,7 @@ CREATE TABLE [dbo].[PAY2_DECREE_LINE]
 (
     [DEC_ID]   INT      NOT NULL,
     [ITEM_ID]  INT      NOT NULL,
-    [AMOUNT]   BIGINT   NOT NULL CONSTRAINT DF_DL_AMT DEFAULT(0),
+    [AMOUNT]   DECIMAL(18,2) NOT NULL CONSTRAINT DF_DL_AMT DEFAULT(0),
     [INS_OV]   BIT      NULL,                                                -- NULL=از PAY2_ITEM_DEF
     [TAX_OV]   BIT      NULL,
     [BASIS_OV] TINYINT  NULL,
@@ -1391,8 +1391,8 @@ BEGIN
         BEGIN
             -- گام ۵ — محاسبه هر آیتم حکم
             DECLARE
-                @ITEM_ID INT, @ITEM_CODE NVARCHAR(30), @ITEM_TYPE TINYINT, @ITEM_AMOUNT BIGINT,
-                @ITEM_BASIS TINYINT, @ITEM_INS BIT, @ITEM_TAX BIT, @ITEM_PBD TINYINT,  
+                @ITEM_ID INT, @ITEM_CODE NVARCHAR(30), @ITEM_TYPE TINYINT, @ITEM_AMOUNT DECIMAL(18,2),
+                @ITEM_BASIS TINYINT, @ITEM_INS BIT, @ITEM_TAX BIT, @ITEM_PBD TINYINT,
                 @OV_INS BIT, @OV_TAX BIT, @OV_BASIS TINYINT, @CALC_AMOUNT BIGINT = 0;
 
             DECLARE cur_line CURSOR LOCAL FAST_FORWARD FOR

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -117,6 +117,7 @@ using (var scope = app.Services.CreateScope())
             //"005_CreateBugReportCommentsTable.sql",
             //"006_Pay2_HourlyCalcBasis.sql",
             //"007_Pay2_HourlyLeaveType.sql",
+            "008_DecreeLineAmountDecimal.sql",
         };
 
         foreach (var scriptName in scriptsToRun)

--- a/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
+++ b/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
@@ -200,7 +200,7 @@ BEGIN
         BEGIN
             -- گام ۵ — محاسبه هر آیتم حکم
             DECLARE
-                @ITEM_ID INT, @ITEM_CODE NVARCHAR(30), @ITEM_TYPE TINYINT, @ITEM_AMOUNT BIGINT,
+                @ITEM_ID INT, @ITEM_CODE NVARCHAR(30), @ITEM_TYPE TINYINT, @ITEM_AMOUNT DECIMAL(18,2),
                 @ITEM_BASIS TINYINT, @ITEM_INS BIT, @ITEM_TAX BIT, @ITEM_PBD TINYINT,  
                 @OV_INS BIT, @OV_TAX BIT, @OV_BASIS TINYINT, @CALC_AMOUNT BIGINT = 0;
 

--- a/Server/Scripts/008_DecreeLineAmountDecimal.sql
+++ b/Server/Scripts/008_DecreeLineAmountDecimal.sql
@@ -1,0 +1,49 @@
+-- Migration 008: تغییر نوع ستون AMOUNT در PAY2_DECREE_LINE و DEF_AMOUNT در PAY2_ITEM_TMPL_LINE از BIGINT به DECIMAL(18,2)
+-- هدف: پشتیبانی از مقادیر اعشاری برای فیلد حق شیفت (PCT) در حکم و قالب‌های حکم
+-- این اسکریپت idempotent است: فقط اگر ستون هنوز BIGINT باشد اجرا می‌شود
+
+-- بخش الف: PAY2_DECREE_LINE.AMOUNT
+IF EXISTS (
+    SELECT 1
+    FROM sys.columns c
+    JOIN sys.types t ON c.user_type_id = t.user_type_id
+    JOIN sys.objects o ON c.object_id = o.object_id
+    WHERE o.name = 'PAY2_DECREE_LINE'
+      AND c.name = 'AMOUNT'
+      AND t.name = 'bigint'
+)
+BEGIN
+    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_DL_AMT')
+        ALTER TABLE [dbo].[PAY2_DECREE_LINE] DROP CONSTRAINT [DF_DL_AMT];
+
+    ALTER TABLE [dbo].[PAY2_DECREE_LINE]
+        ALTER COLUMN [AMOUNT] DECIMAL(18,2) NOT NULL;
+
+    ALTER TABLE [dbo].[PAY2_DECREE_LINE]
+        ADD CONSTRAINT [DF_DL_AMT] DEFAULT(0) FOR [AMOUNT];
+END
+GO
+
+-- بخش ب: PAY2_ITEM_TMPL_LINE.DEF_AMOUNT
+-- دلیل: INSERT INTO PAY2_DECREE_LINE ... SELECT DEF_AMOUNT FROM PAY2_ITEM_TMPL_LINE
+-- اگر DEF_AMOUNT همچنان BIGINT باشد، مقادیر اعشاری (مثل 7.5 برای حق شیفت) هنگام کپی به حکم گرد می‌شوند
+IF EXISTS (
+    SELECT 1
+    FROM sys.columns c
+    JOIN sys.types t ON c.user_type_id = t.user_type_id
+    JOIN sys.objects o ON c.object_id = o.object_id
+    WHERE o.name = 'PAY2_ITEM_TMPL_LINE'
+      AND c.name = 'DEF_AMOUNT'
+      AND t.name = 'bigint'
+)
+BEGIN
+    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TL_AMT')
+        ALTER TABLE [dbo].[PAY2_ITEM_TMPL_LINE] DROP CONSTRAINT [DF_TL_AMT];
+
+    ALTER TABLE [dbo].[PAY2_ITEM_TMPL_LINE]
+        ALTER COLUMN [DEF_AMOUNT] DECIMAL(18,2) NOT NULL;
+
+    ALTER TABLE [dbo].[PAY2_ITEM_TMPL_LINE]
+        ADD CONSTRAINT [DF_TL_AMT] DEFAULT(0) FOR [DEF_AMOUNT];
+END
+GO

--- a/Shared/Models/Salary/Pay2EmployeeModels.cs
+++ b/Shared/Models/Salary/Pay2EmployeeModels.cs
@@ -65,7 +65,7 @@
         public int DEC_ID { get; set; }
         public int ITEM_ID { get; set; }
         public string? ITEM_NAME { get; set; }
-        public long AMOUNT { get; set; }
+        public decimal AMOUNT { get; set; }
 
         public bool? INS_OV { get; set; }
         public bool? TAX_OV { get; set; }
@@ -333,7 +333,7 @@
         public int TMPL_ID { get; set; }
         public int ITEM_ID { get; set; }
         public string? ITEM_NAME { get; set; }
-        public long DEF_AMOUNT { get; set; }
+        public decimal DEF_AMOUNT { get; set; }
         public bool? INS_OV { get; set; }
         public bool? TAX_OV { get; set; }
         public byte? BASIS_OV { get; set; }


### PR DESCRIPTION
## خلاصه

پشتیبانی کامل از مقادیر اعشاری (مثلاً `7.5%`) در فیلد حق شیفت، به همراه رفع باگ ضرب‌در‌۱۰۰ هنگام ویرایش آیتم‌های ریالی.

---

## مشکلات رفع‌شده

### ۱. فیلد حق شیفت فقط عدد صحیح می‌پذیرفت
در حالت `SHIFT_MODE=PCT`، مقدار درصد (مثلاً `7.5`) در فیلد ورودی پذیرفته نمی‌شد — نقطه اعشار حذف می‌شد.

### ۲. باگ ×100 هنگام ویرایش آیتم‌های ریالی (P1)
پس از تغییر نوع `AMOUNT` به `DECIMAL(18,2)`، مقدار `5000000.00` هنگام بارگذاری در فرم ویرایش به `"5000000.00"` تبدیل می‌شد. کامپوننت `Pay2NumericInput` در حالت `InputMode.None` نقطه را حذف اما ارقام بعد از آن را نگه می‌داشت → `500000000` (ضرب‌در‌۱۰۰).

### ۳. DEF_AMOUNT در قالب‌های حکم truncate می‌شد
هنگام کپی قالب به حکم، `INSERT INTO PAY2_DECREE_LINE ... SELECT DEF_AMOUNT FROM PAY2_ITEM_TMPL_LINE` اگر `DEF_AMOUNT` همچنان `BIGINT` بود، مقدار `7.5` به `7` گرد می‌شد.

---

## تغییرات

### پایگاه داده — نصب تازه (`ScriptSqly.cs`)
- `PAY2_DECREE_LINE.AMOUNT`: `BIGINT` → `DECIMAL(18,2)`
- `PAY2_ITEM_TMPL_LINE.DEF_AMOUNT`: `BIGINT` → `DECIMAL(18,2)`
- `SP_PAY2_CALC_RUN`: متغیر `@ITEM_AMOUNT` از `BIGINT` به `DECIMAL(18,2)` (فرمول شیفت: `BASE_SAL_B × MONTH_DAYS × ITEM_AMOUNT / 100.0` به درستی ۷.۵٪ محاسبه می‌کند)

### پایگاه داده — نصب‌های موجود (`008_DecreeLineAmountDecimal.sql`)
Migration کاملاً idempotent — فقط اگر ستون هنوز `BIGINT` باشد اجرا می‌شود:
```sql
IF EXISTS (SELECT 1 FROM sys.columns c JOIN sys.types t ... WHERE t.name = 'bigint')
BEGIN
    ALTER TABLE [dbo].[PAY2_DECREE_LINE] ALTER COLUMN [AMOUNT] DECIMAL(18,2) NOT NULL;
END
```
هر دو جدول (`PAY2_DECREE_LINE` و `PAY2_ITEM_TMPL_LINE`) پوشش داده شده‌اند.

### `Program.cs`
اسکریپت `008_DecreeLineAmountDecimal.sql` به `scriptsToRun` اضافه شد.

### `Pay2EmployeeModels.cs`
- `Pay2DecreeLineDto.AMOUNT`: `long` → `decimal`
- `Pay2ItemTmplLineDto.DEF_AMOUNT`: `long` → `decimal`

### `DecreeLineModal.razor`
- `InputMode=Percentage` و `MaxDecimalPlaces=2` برای آیتم‌های شیفت PCT
- رفع باگ ×100: در `EditLine()` آیتم غیرشیفت با فرمت `"0"` لود می‌شود (بدون اعشار)
- `UpdateShiftHint` و `SubmitSave`: `long.TryParse` → `decimal.TryParse` با `InvariantCulture`
- `GetMonthlyBaseSalary`: نوع بازگشتی `long?` → `decimal?`

### `ItemTemplateLineModal.razor`
- بارگذاری `FullItemDefs` و `SHIFT_MODE` (موازی، بدون تأخیر اضافه)
- تشخیص خودکار آیتم SHIFT از طریق `ITEM_CODE` و سوئیچ `InputMode` به `Percentage`
- رفع باگ ×100: در `EditLine()` آیتم غیرشیفت با `Truncate→long` لود می‌شود
- `OnItemChanged`: ریست مبلغ هنگام تغییر آیتم انتخابی
- `SubmitSave`: `long.TryParse` → `decimal.TryParse` با `InvariantCulture`
- نمایش `٪` در جدول برای ردیف‌های شیفت

### فایل‌های مرجع
`PAY2_DDL_v6.sql`، `PAY2_Procedures_v6.sql`، `006_Pay2_HourlyCalcBasis.sql` برای یکپارچگی به‌روز شدند.

---

## نکات فنی مهم

- `#ItemCalc.AMOUNT` در SP همچنان `BIGINT` است — این جدول موقت **خروجی ریال محاسبه‌شده** را نگه می‌دارد، نه ورودی درصد.
- SQL Server به‌طور خودکار `BIGINT × INT × DECIMAL(18,2)` را به `DECIMAL` ارتقاء می‌دهد، بنابراین فرمول شیفت بدون تغییر اضافه درست کار می‌کند.
- Migration ۰۰۸ ابتدا constraint پیش‌فرض را drop و سپس با نام یکسان بازمی‌سازد تا اجرای مکرر مشکل ایجاد نکند.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2JcPjHycDbWamBykk4SEy)_