### PR TITLE
feat: لغو تأیید حکم کارگزینی (Unlock Decree)

### DIFF
--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
@@ -34,10 +34,15 @@
                 <!-- 🚀 پیام اطلاع‌رسانی به کاربر (UX) -->
                 @if (IsDecreeConfirmed)
                 {
-                    <div style="background: var(--p2-warning-bg); border: 1px solid var(--p2-warning-border); border-radius: var(--p2-radius-md); padding: 12px 16px; margin-bottom: 16px; flex-shrink: 0; display:flex; gap:10px; align-items:center;">
-                        <i class="bi bi-shield-lock" style="color: var(--p2-warning-text); font-size: 18px;"></i>
-                        <span style="font-size:13px; color: var(--p2-text-main);">
-                            این حکم <b>تأیید نهایی</b> شده است. برای حفظ یکپارچگی اطلاعات، امکان افزودن، ویرایش یا حذف آیتم‌های ریالی وجود ندارد.
+                    <div style="background: var(--p2-warning-bg); border: 1px solid var(--p2-warning-border); border-radius: var(--p2-radius-md); padding: 12px 16px; margin-bottom: 16px; flex-shrink: 0; display:flex; gap:10px; align-items:flex-start;">
+                        <i class="bi bi-shield-lock" style="color: var(--p2-warning-text); font-size: 18px; margin-top: 2px;"></i>
+                        <span style="font-size:13px; color: var(--p2-text-main); line-height: 1.8;">
+                            این حکم <b>تأیید نهایی</b> شده است و آیتم‌های آن قابل تغییر نیستند.<br />
+                            <span style="color: var(--p2-text-muted);">
+                                برای ویرایش، از صفحه قبل روی دکمه
+                                <b style="color: var(--p2-warning-text);"><i class="bi bi-unlock"></i> لغو تأیید</b>
+                                کلیک کنید — در صورتی که حقوق این دوره قطعی نشده باشد، حکم باز می‌شود.
+                            </span>
                         </span>
                     </div>
                 }

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
@@ -269,18 +269,16 @@
         try
         {
             // منتظر می‌مانیم تا هم لیست تعاریف آیتم‌ها و هم اقلام ریالی این حکم به طور کامل لود شوند
-            // چهار فراخوانی مستقل به صورت موازی اجرا می‌شوند تا باز شدن مودال سریع‌تر باشد
-            var itemDefsTask = EmployeeApi.GetItemDefsLookupAsync();
             var linesTask = EmployeeApi.GetDecreeLinesAsync(DecreeId);
             var fullDefsTask = ItemDefApi.GetItemDefsAsync();
-            var shiftModeTask = LoadShiftModeAsync();
+            var shiftModeTask = SettingsApi.GetShiftModeAsync();
 
-            await Task.WhenAll(itemDefsTask, linesTask, fullDefsTask, shiftModeTask);
+            await Task.WhenAll(linesTask, fullDefsTask, shiftModeTask);
 
-            ItemDefs = itemDefsTask.Result;
             Lines = linesTask.Result;
             FullItemDefs = fullDefsTask.Result;
             _shiftMode = shiftModeTask.Result;
+            ItemDefs = FullItemDefs.Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? "")).ToList();
         }
         catch (Exception ex)
         {
@@ -327,22 +325,8 @@
         ShiftHint = null;
     }
 
-    bool IsShiftPctLine(Pay2DecreeLineDto line)
-    {
-        if (string.Equals(_shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase)) return false;
-        var def = FullItemDefs.FirstOrDefault(d => d.ITEM_ID == line.ITEM_ID);
-        return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
-    }
-
-    async Task<string> LoadShiftModeAsync()
-    {
-        try
-        {
-            var configs = await SettingsApi.GetConfigsAsync();
-            return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
-        }
-        catch { return "PCT"; }
-    }
+    bool IsShiftPctLine(Pay2DecreeLineDto line) =>
+        Pay2SettingsApiService.IsShiftPctItem(_shiftMode, FullItemDefs, line.ITEM_ID);
 
     // منطق مشترک «درصد × حقوق پایه ماهیانه» برای هر دو کمک‌محاسبه (شیفت و عمومی)
     (long? Computed, string Hint) CalcPercentOfMonthly(decimal pct)
@@ -431,10 +415,13 @@
             Snackbar.Add("انتخاب آیتم حقوقی الزامی است.", MudBlazor.Severity.Warning); return;
         }
 
-        decimal.TryParse(CurrentAmountStr?.Replace(",", ""),
-            System.Globalization.NumberStyles.Number,
-            System.Globalization.CultureInfo.InvariantCulture,
-            out decimal amt);
+        if (!decimal.TryParse(CurrentAmountStr?.Replace(",", ""),
+                System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out decimal amt) || amt <= 0)
+        {
+            Snackbar.Add("مبلغ وارد شده معتبر نیست.", MudBlazor.Severity.Warning); return;
+        }
 
         CurrentLine.DEC_ID = DecreeId;
         CurrentLine.AMOUNT = amt;

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor
@@ -204,8 +204,11 @@
     {
         try
         {
-            Templates = await EmployeeApi.GetTemplatesLookupAsync();
-            Decrees = await EmployeeApi.GetDecreesAsync(EmployeeId);
+            var templatesTask = EmployeeApi.GetTemplatesLookupAsync();
+            var decreesTask = EmployeeApi.GetDecreesAsync(EmployeeId);
+            await Task.WhenAll(templatesTask, decreesTask);
+            Templates = templatesTask.Result;
+            Decrees = decreesTask.Result;
         }
         catch (Exception ex) { Snackbar.Add(ex.Message, MudBlazor.Severity.Error); }
     }

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor
@@ -314,9 +314,13 @@
         {
             try
             {
-                var toUnlock = System.Text.Json.JsonSerializer.Deserialize<Pay2DecreeDto>(
-                    System.Text.Json.JsonSerializer.Serialize(dec))!;
-                toUnlock.IS_CONFIRMED = false;
+                var toUnlock = new Pay2DecreeDto
+                {
+                    DEC_ID = dec.DEC_ID, EMP_ID = dec.EMP_ID, WS_ID = dec.WS_ID,
+                    ISSUED_DATE = dec.ISSUED_DATE, EFF_FROM = dec.EFF_FROM, EFF_TO = dec.EFF_TO,
+                    EDU_LEVEL = dec.EDU_LEVEL, MARITAL = dec.MARITAL, IS_MANAGER = dec.IS_MANAGER,
+                    TMPL_ID = dec.TMPL_ID, NOTES = dec.NOTES, IS_CONFIRMED = false
+                };
                 await EmployeeApi.SaveDecreeAsync(toUnlock);
                 Snackbar.Add("تأیید حکم با موفقیت لغو شد. اکنون می‌توانید آیتم‌های ریالی را ویرایش کنید.", MudBlazor.Severity.Success);
                 await LoadData();

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor
@@ -123,10 +123,19 @@
                                         <i class="bi bi-square" style="color:var(--p2-text-light); font-size:16px;"></i>
                                     }
                                 </td>
-                                <td style="text-align:center; min-width: 250px;">
+                                <td style="text-align:center; min-width: 280px;">
                                     <button class="btn-ghost-pay2" style="color:#8b5cf6;" @onclick="() => OpenDecreeLines(dec)">آیتم‌های ریالی</button>
-                                    <button class="btn-ghost-pay2 p2-text-primary" @onclick="() => EditDecree(dec)">ویرایش</button>
-                                    <button class="btn-ghost-pay2 p2-text-danger" @onclick="() => DeleteDecree(dec)">حذف</button>
+                                    @if (dec.IS_CONFIRMED)
+                                    {
+                                        <button class="btn-ghost-pay2" style="color: var(--p2-warning-text);" @onclick="() => UnlockDecree(dec)" title="لغو تأیید نهایی — فقط اگر حقوق قطعی نشده باشد">
+                                            <i class="bi bi-unlock"></i> لغو تأیید
+                                        </button>
+                                    }
+                                    else
+                                    {
+                                        <button class="btn-ghost-pay2 p2-text-primary" @onclick="() => EditDecree(dec)">ویرایش</button>
+                                        <button class="btn-ghost-pay2 p2-text-danger" @onclick="() => DeleteDecree(dec)">حذف</button>
+                                    }
                                 </td>
                             </tr>
                         }
@@ -283,6 +292,34 @@
     async Task CloseDecreeLineModal()
     {
         ShowDecreeLineModal = false;
+    }
+
+    async Task UnlockDecree(Pay2DecreeDto dec)
+    {
+        var parameters = new MudBlazor.DialogParameters
+        {
+            ["Title"] = "لغو تأیید حکم",
+            ["ContentText"] = $"آیا از لغو تأیید حکم (شروع اجرا: {dec.EFF_FROM}) اطمینان دارید؟\nدر صورتی که حقوق این دوره قطعی نشده باشد، حکم برای ویرایش باز می‌شود.",
+            ["ConfirmButtonText"] = "بله، لغو تأیید",
+            ["CancelButtonText"] = "انصراف"
+        };
+        var options = new MudBlazor.DialogOptions { CloseButton = false, MaxWidth = MudBlazor.MaxWidth.ExtraSmall };
+        var dialog = DialogService.Show<Safir.Client.Shared.ConfirmDialog>("لغو تأیید", parameters, options);
+        var result = await dialog.Result;
+
+        if (!result.Cancelled)
+        {
+            try
+            {
+                var toUnlock = System.Text.Json.JsonSerializer.Deserialize<Pay2DecreeDto>(
+                    System.Text.Json.JsonSerializer.Serialize(dec))!;
+                toUnlock.IS_CONFIRMED = false;
+                await EmployeeApi.SaveDecreeAsync(toUnlock);
+                Snackbar.Add("تأیید حکم با موفقیت لغو شد. اکنون می‌توانید آیتم‌های ریالی را ویرایش کنید.", MudBlazor.Severity.Success);
+                await LoadData();
+            }
+            catch (Exception ex) { Snackbar.Add(ex.Message, MudBlazor.Severity.Error); }
+        }
     }
 
     async Task Close() => await OnClose.InvokeAsync();

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
@@ -164,12 +164,8 @@
 
     bool IsShiftPctItem => IsShiftPctLine(CurrentLine);
 
-    bool IsShiftPctLine(Pay2ItemTmplLineDto line)
-    {
-        if (string.Equals(_shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase)) return false;
-        var def = FullItemDefs.FirstOrDefault(d => d.ITEM_ID == line.ITEM_ID);
-        return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
-    }
+    bool IsShiftPctLine(Pay2ItemTmplLineDto line) =>
+        Pay2SettingsApiService.IsShiftPctItem(_shiftMode, FullItemDefs, line.ITEM_ID);
 
     List<LookupDto<int>> OverrideOptions = new() { new(3, "طبق تعریف پایه"), new(1, "مشمول"), new(2, "معاف") };
     List<LookupDto<int>> BasisOptions = new() { new(9, "طبق تعریف پایه"), new(1, "روزانه"), new(2, "ماهیانه"), new(3, "ساعتی") };
@@ -194,17 +190,16 @@
     {
         try
         {
-            var itemDefsTask = EmployeeApi.GetItemDefsLookupAsync();
             var linesTask = EmployeeApi.GetTemplateLinesAsync(MasterTemplateId);
             var fullDefsTask = ItemDefApi.GetItemDefsAsync();
-            var shiftModeTask = LoadShiftModeAsync();
+            var shiftModeTask = SettingsApi.GetShiftModeAsync();
 
-            await Task.WhenAll(itemDefsTask, linesTask, fullDefsTask, shiftModeTask);
+            await Task.WhenAll(linesTask, fullDefsTask, shiftModeTask);
 
-            ItemDefs = itemDefsTask.Result;
             Lines = linesTask.Result;
             FullItemDefs = fullDefsTask.Result;
             _shiftMode = shiftModeTask.Result;
+            ItemDefs = FullItemDefs.Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? "")).ToList();
         }
         catch (Exception ex) { Console.WriteLine(ex.Message); }
         finally
@@ -212,16 +207,6 @@
             _isDataLoaded = true;
             StateHasChanged();
         }
-    }
-
-    async Task<string> LoadShiftModeAsync()
-    {
-        try
-        {
-            var configs = await SettingsApi.GetConfigsAsync();
-            return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
-        }
-        catch { return "PCT"; }
     }
 
     void ResetForm()
@@ -250,7 +235,7 @@
         };
         AmountStr = IsShiftPctItem
             ? CurrentLine.DEF_AMOUNT.ToString(System.Globalization.CultureInfo.InvariantCulture)
-            : ((long)decimal.Truncate(CurrentLine.DEF_AMOUNT)).ToString();
+            : CurrentLine.DEF_AMOUNT.ToString("0", System.Globalization.CultureInfo.InvariantCulture);
         IsEditing = true;
     }
 
@@ -260,10 +245,13 @@
         {
             Snackbar.Add("انتخاب آیتم حقوقی الزامی است.", MudBlazor.Severity.Warning); return;
         }
-        decimal.TryParse(AmountStr?.Replace(",", ""),
-            System.Globalization.NumberStyles.Number,
-            System.Globalization.CultureInfo.InvariantCulture,
-            out decimal amt);
+        if (!decimal.TryParse(AmountStr?.Replace(",", ""),
+                System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out decimal amt) || amt <= 0)
+        {
+            Snackbar.Add("مبلغ وارد شده معتبر نیست.", MudBlazor.Severity.Warning); return;
+        }
         CurrentLine.TMPL_ID = MasterTemplateId;
         CurrentLine.DEF_AMOUNT = amt;
         IsSaving = true;

--- a/Client/Services/Pay2SettingsApiService.cs
+++ b/Client/Services/Pay2SettingsApiService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http.Json;
+using Safir.Shared.Models;
 using Safir.Shared.Models.Salary;
 
 namespace Safir.Client.Services
@@ -46,6 +47,23 @@ namespace Safir.Client.Services
             var res = await _http.PostAsJsonAsync("api/pay2/settings/tax/brackets/copy-year", request);
             if (!res.IsSuccessStatusCode)
                 throw new Exception(await res.Content.ReadAsStringAsync());
+        }
+
+        public async Task<string> GetShiftModeAsync()
+        {
+            try
+            {
+                var configs = await GetConfigsAsync();
+                return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
+            }
+            catch { return "PCT"; }
+        }
+
+        public static bool IsShiftPctItem(string shiftMode, IEnumerable<Pay2ItemDefDto> defs, int itemId)
+        {
+            if (string.Equals(shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase)) return false;
+            var def = defs.FirstOrDefault(d => d.ITEM_ID == itemId);
+            return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -223,10 +223,24 @@ namespace Safir.Server.Controllers
                         }
                         else
                         {
+                            if (wasConfirmed && !decree.IS_CONFIRMED)
+                            {
+                                const string checkRunSql = @"
+                            SELECT COUNT(1) FROM PAY2_RUN R
+                            JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
+                            JOIN PAY2_RUN_LINE RL ON R.RUN_ID = RL.RUN_ID
+                            JOIN PAY2_DECREE D ON D.DEC_ID = @DEC_ID AND RL.EMP_ID = D.EMP_ID
+                            WHERE R.STATUS >= 2
+                            AND P.PERIOD_DATE >= (D.EFF_FROM / 100) * 100";
+                                int finalRunCount = await conn.QuerySingleAsync<int>(checkRunSql, new { decree.DEC_ID }, tran);
+                                if (finalRunCount > 0)
+                                    throw new InvalidOperationException("این حکم در محاسبه حقوق قطعی‌شده استفاده شده است. جهت اصلاح، باید حکم جدید اصلاحی صادر کنید.");
+                            }
+
                             const string updateSql = @"
-                        UPDATE PAY2_DECREE 
-                        SET ISSUED_DATE=@ISSUED_DATE, EFF_FROM=@EFF_FROM, EFF_TO=@EFF_TO, 
-                            EDU_LEVEL=@EDU_LEVEL, MARITAL=@MARITAL, IS_MANAGER=@IS_MANAGER, 
+                        UPDATE PAY2_DECREE
+                        SET ISSUED_DATE=@ISSUED_DATE, EFF_FROM=@EFF_FROM, EFF_TO=@EFF_TO,
+                            EDU_LEVEL=@EDU_LEVEL, MARITAL=@MARITAL, IS_MANAGER=@IS_MANAGER,
                             IS_CONFIRMED=@IS_CONFIRMED, NOTES=@NOTES
                         WHERE DEC_ID=@DEC_ID";
                             await conn.ExecuteAsync(updateSql, decree, tran);

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -162,20 +162,20 @@ namespace Safir.Server.Controllers
                 {
                     int currentDecId = decree.DEC_ID;
 
-                    // گارد امنیتی: بررسی تداخل با فیش‌های قطعی‌شده در بازه اجرای همین حکم
+                    // گارد امنیتی: بررسی تداخل با فیش‌های قطعی‌شده در بازه اجرای پیشنهادی حکم
+                    // از مقادیر ورودی (نه DB) استفاده می‌شود تا extend کردن EFF_TO به ماه‌های قطعی نیز بلاک شود
                     if (currentDecId > 0)
                     {
                         string checkUsageSql = @"
                     SELECT COUNT(1)
                     FROM PAY2_RUN R
                     INNER JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
-                    INNER JOIN PAY2_DECREE D ON D.DEC_ID = @DEC_ID
                     WHERE R.STATUS >= 2
-                      AND (P.PERIOD_DATE / 100) >= (D.EFF_FROM / 100)
-                      AND (D.EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (D.EFF_TO / 100))
+                      AND (P.PERIOD_DATE / 100) >= (@EFF_FROM / 100)
+                      AND (@EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (@EFF_TO / 100))
                       AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
 
-                        int usedInFinalRun = await conn.QuerySingleAsync<int>(checkUsageSql, new { DEC_ID = currentDecId, EMP_ID = decree.EMP_ID }, tran);
+                        int usedInFinalRun = await conn.QuerySingleAsync<int>(checkUsageSql, new { decree.EFF_FROM, EFF_TO = (long?)decree.EFF_TO, EMP_ID = decree.EMP_ID }, tran);
 
                         if (usedInFinalRun > 0)
                             throw new InvalidOperationException("این حکم در ماه‌های گذشته جهت صدور حقوق قطعی استفاده شده است. امکان ویرایش یا لغو تایید آن به هیچ وجه وجود ندارد. برای تغییر حقوق، باید یک حکم جدید صادر کنید.");

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -162,25 +162,6 @@ namespace Safir.Server.Controllers
                 {
                     int currentDecId = decree.DEC_ID;
 
-                    // گارد امنیتی: بررسی تداخل با فیش‌های قطعی‌شده در بازه اجرای پیشنهادی حکم
-                    // از مقادیر ورودی (نه DB) استفاده می‌شود تا extend کردن EFF_TO به ماه‌های قطعی نیز بلاک شود
-                    if (currentDecId > 0)
-                    {
-                        string checkUsageSql = @"
-                    SELECT COUNT(1)
-                    FROM PAY2_RUN R
-                    INNER JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
-                    WHERE R.STATUS >= 2
-                      AND (P.PERIOD_DATE / 100) >= (@EFF_FROM / 100)
-                      AND (@EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (@EFF_TO / 100))
-                      AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
-
-                        int usedInFinalRun = await conn.QuerySingleAsync<int>(checkUsageSql, new { decree.EFF_FROM, EFF_TO = (long?)decree.EFF_TO, EMP_ID = decree.EMP_ID }, tran);
-
-                        if (usedInFinalRun > 0)
-                            throw new InvalidOperationException("این حکم در ماه‌های گذشته جهت صدور حقوق قطعی استفاده شده است. امکان ویرایش یا لغو تایید آن به هیچ وجه وجود ندارد. برای تغییر حقوق، باید یک حکم جدید صادر کنید.");
-                    }
-
                     if (currentDecId == 0) // درج جدید
                     {
                         // بستن هوشمند تاریخ حکم قبلی
@@ -214,6 +195,27 @@ namespace Safir.Server.Controllers
                     else // ویرایش
                     {
                         bool wasConfirmed = await conn.QuerySingleAsync<bool>("SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID", new { decree.DEC_ID }, tran);
+
+                        // فقط احکام تأییدشده مسدود می‌شوند — احکام تأییدنشده هرگز در حقوق استفاده نشده‌اند
+                        // از تاریخ‌های ذخیره‌شده در DB استفاده می‌شود تا bypass از طریق دستکاری تاریخ ممکن نباشد
+                        if (wasConfirmed)
+                        {
+                            const string checkUsageSql = @"
+                        SELECT COUNT(1)
+                        FROM PAY2_RUN R
+                        INNER JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
+                        INNER JOIN PAY2_DECREE D ON D.DEC_ID = @DEC_ID
+                        WHERE R.STATUS >= 2
+                          AND (P.PERIOD_DATE / 100) >= (D.EFF_FROM / 100)
+                          AND (D.EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (D.EFF_TO / 100))
+                          AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
+
+                            int usedInFinalRun = await conn.QuerySingleAsync<int>(
+                                checkUsageSql, new { DEC_ID = currentDecId, EMP_ID = decree.EMP_ID }, tran);
+
+                            if (usedInFinalRun > 0)
+                                throw new InvalidOperationException("این حکم در ماه‌های گذشته جهت صدور حقوق قطعی استفاده شده است. امکان ویرایش یا لغو تایید آن به هیچ وجه وجود ندارد. برای تغییر حقوق، باید یک حکم جدید صادر کنید.");
+                        }
 
                         // 🛠 رفع بن‌بست منطقی: فقط زمانی آپدیت را به NOTES محدود کن که کاربر هنوز می‌خواهد حکم تایید شده بماند.
                         // اگر کاربر تیک تایید را در UI برداشته باشد (decree.IS_CONFIRMED == false)، باید اجازه دهیم کل حکم از قفل خارج شود.

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -226,6 +226,28 @@ namespace Safir.Server.Controllers
                         }
                         else
                         {
+                            // گارد تأیید مجدد: احکامی که پس از unlock دوباره تأیید می‌شوند
+                            // باید تاریخ‌های ورودی بررسی شود تا مانع backdating به ماه‌های قطعی‌شده شویم
+                            if (!wasConfirmed && decree.IS_CONFIRMED)
+                            {
+                                const string checkReconfirmSql = @"
+                        SELECT COUNT(1)
+                        FROM PAY2_RUN R
+                        INNER JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
+                        WHERE R.STATUS >= 2
+                          AND (P.PERIOD_DATE / 100) >= (@EFF_FROM / 100)
+                          AND (@EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (@EFF_TO / 100))
+                          AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
+
+                                int reconfirmConflict = await conn.QuerySingleAsync<int>(
+                                    checkReconfirmSql,
+                                    new { EFF_FROM = decree.EFF_FROM, EFF_TO = (long?)decree.EFF_TO, EMP_ID = decree.EMP_ID },
+                                    tran);
+
+                                if (reconfirmConflict > 0)
+                                    throw new InvalidOperationException("بازه زمانی این حکم با ماه‌هایی که حقوق آنها قطعی شده تداخل دارد. لطفاً بازه تاریخی را اصلاح کنید یا با دوره‌های تأیید نشده کار کنید.");
+                            }
+
                             const string updateSql = @"
                         UPDATE PAY2_DECREE
                         SET ISSUED_DATE=@ISSUED_DATE, EFF_FROM=@EFF_FROM, EFF_TO=@EFF_TO,

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -162,16 +162,17 @@ namespace Safir.Server.Controllers
                 {
                     int currentDecId = decree.DEC_ID;
 
-                    // 🚀 گارد امنیتی سطح ۱: بررسی تداخل با فیش‌های قطعی‌شده
+                    // گارد امنیتی: بررسی تداخل با فیش‌های قطعی‌شده در بازه اجرای همین حکم
                     if (currentDecId > 0)
                     {
                         string checkUsageSql = @"
-                    SELECT COUNT(1) 
+                    SELECT COUNT(1)
                     FROM PAY2_RUN R
                     INNER JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
-                    WHERE R.STATUS >= 2 
-                      -- 🛠 رفع باگ مقایسه تاریخ: تبدیل هر دو تاریخ به YYYYMM
-                      AND (P.PERIOD_DATE / 100) >= (SELECT (EFF_FROM / 100) FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID)
+                    INNER JOIN PAY2_DECREE D ON D.DEC_ID = @DEC_ID
+                    WHERE R.STATUS >= 2
+                      AND (P.PERIOD_DATE / 100) >= (D.EFF_FROM / 100)
+                      AND (D.EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (D.EFF_TO / 100))
                       AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
 
                         int usedInFinalRun = await conn.QuerySingleAsync<int>(checkUsageSql, new { DEC_ID = currentDecId, EMP_ID = decree.EMP_ID }, tran);
@@ -223,20 +224,6 @@ namespace Safir.Server.Controllers
                         }
                         else
                         {
-                            if (wasConfirmed && !decree.IS_CONFIRMED)
-                            {
-                                const string checkRunSql = @"
-                            SELECT COUNT(1) FROM PAY2_RUN R
-                            JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
-                            JOIN PAY2_RUN_LINE RL ON R.RUN_ID = RL.RUN_ID
-                            JOIN PAY2_DECREE D ON D.DEC_ID = @DEC_ID AND RL.EMP_ID = D.EMP_ID
-                            WHERE R.STATUS >= 2
-                            AND P.PERIOD_DATE >= (D.EFF_FROM / 100) * 100";
-                                int finalRunCount = await conn.QuerySingleAsync<int>(checkRunSql, new { decree.DEC_ID }, tran);
-                                if (finalRunCount > 0)
-                                    throw new InvalidOperationException("این حکم در محاسبه حقوق قطعی‌شده استفاده شده است. جهت اصلاح، باید حکم جدید اصلاحی صادر کنید.");
-                            }
-
                             const string updateSql = @"
                         UPDATE PAY2_DECREE
                         SET ISSUED_DATE=@ISSUED_DATE, EFF_FROM=@EFF_FROM, EFF_TO=@EFF_TO,

--- a/Server/Info/PAY2_Procedures_v6.sql
+++ b/Server/Info/PAY2_Procedures_v6.sql
@@ -239,7 +239,7 @@ BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
                             -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
-                            SET @CALC_AMOUNT = CAST(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0 AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;
                     END;
                     ELSE

--- a/Server/Info/ScriptSqly.cs
+++ b/Server/Info/ScriptSqly.cs
@@ -1453,7 +1453,7 @@ BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
                             -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
-                            SET @CALC_AMOUNT = CAST(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0 AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;
                     END;
                     ELSE

--- a/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
+++ b/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
@@ -262,7 +262,7 @@ BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
                             -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
-                            SET @CALC_AMOUNT = CAST(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0 AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;
                     END;
                     ELSE

--- a/Server/Scripts/008_DecreeLineAmountDecimal.sql
+++ b/Server/Scripts/008_DecreeLineAmountDecimal.sql
@@ -13,7 +13,7 @@ IF EXISTS (
       AND t.name = 'bigint'
 )
 BEGIN
-    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_DL_AMT')
+    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_DL_AMT' AND parent_object_id = OBJECT_ID('dbo.PAY2_DECREE_LINE'))
         ALTER TABLE [dbo].[PAY2_DECREE_LINE] DROP CONSTRAINT [DF_DL_AMT];
 
     ALTER TABLE [dbo].[PAY2_DECREE_LINE]

--- a/Server/Scripts/008_DecreeLineAmountDecimal.sql
+++ b/Server/Scripts/008_DecreeLineAmountDecimal.sql
@@ -37,7 +37,7 @@ IF EXISTS (
       AND t.name = 'bigint'
 )
 BEGIN
-    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TL_AMT')
+    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TL_AMT' AND parent_object_id = OBJECT_ID('dbo.PAY2_ITEM_TMPL_LINE'))
         ALTER TABLE [dbo].[PAY2_ITEM_TMPL_LINE] DROP CONSTRAINT [DF_TL_AMT];
 
     ALTER TABLE [dbo].[PAY2_ITEM_TMPL_LINE]


### PR DESCRIPTION
## خلاصه

این PR قابلیت **لغو تأیید حکم کارگزینی** را پیاده‌سازی می‌کند و ۱۰ باگ امنیتی، منطقی و کیفیتی را که در طی چندین دور code review کشف شدند برطرف می‌کند.

---

## مشکل

احکام کارگزینی پس از تأیید نهایی (`IS_CONFIRMED = true`) کاملاً قفل می‌شدند. هیچ راهی برای بازگشت وجود نداشت — حتی اگر هنوز هیچ فیش حقوقی برای آن دوره صادر نشده بود. اگر کاربر به اشتباه تأیید می‌کرد، مجبور بود حکم را حذف و از صفر وارد کند.

---

## راه‌حل

### ۱. دکمه «لغو تأیید» — `DecreeModal.razor`

- در جدول سوابق احکام، برای هر حکم تأییدشده دکمه **لغو تأیید** نمایش داده می‌شود (به جای دکمه‌های ویرایش/حذف)
- Dialog تأیید قبل از اجرا نشان داده می‌شود
- پیام خطای سرور در صورت وجود فیش قطعی به کاربر نمایش داده می‌شود
- بارگذاری موازی با `Task.WhenAll` برای باز شدن سریع‌تر مودال

### ۲. بنر راهنما — `DecreeLineModal.razor`

بنر قفل قبلی فقط می‌گفت «قابل تغییر نیست». حالا توضیح می‌دهد که از کجا و چطور قفل را باز کند.

### ۳. گارد امنیتی چندلایه — `Pay2EmployeesController.cs`

حکم **فقط** در صورتی قابل ویرایش یا لغو تأیید است که در هیچ فیش حقوقی قطعی‌شده (`PAY2_RUN.STATUS >= 2`) استفاده نشده باشد:

```
کاربر: لغو تأیید / ویرایش حکم
    ↓
سرور: wasConfirmed = SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @id
    ↓
wasConfirmed = true  →  چک استفاده در حقوق قطعی (با تاریخ‌های DB، نه client)
    ↓
    استفاده شده → خطا: «امکان ویرایش وجود ندارد»
    نشده → ادامه
    ↓
!wasConfirmed && IS_CONFIRMED = true  →  گارد re-confirmation با incoming dates
    ↓
    تداخل با ماه قطعی‌شده → خطا
    بدون تداخل → UPDATE حکم
```

**سه لایه محافظت:**
- **لایه ۱:** فقط احکام تأییدشده بررسی می‌شوند (unconfirmed هرگز در حقوق نبوده‌اند)
- **لایه ۲:** از تاریخ‌های DB استفاده می‌کند تا bypass از طریق دستکاری date ممکن نباشد
- **لایه ۳:** re-confirmation نیز بررسی می‌شود تا backdating به ماه‌های قطعی‌شده ممکن نباشد

### ۴. تولید مشترک از سرویس — `Pay2SettingsApiService.cs`

متدهای `GetShiftModeAsync()` و `IsShiftPctItem()` که در دو کامپوننت تکرار شده بودند به سرویس منتقل شدند.

---

## باگ‌های برطرف‌شده

| # | شدت | فایل | توضیح |
|---|-----|------|--------|
| 1 | 🔴 بحرانی | `PAY2_Procedures_v6.sql` | `CAST AS BIGINT` برای حق شیفت اعشاری (مثل 12.5%) مقدار را truncate می‌کرد → رفع: `CAST(ROUND(..., 0) AS BIGINT)` |
| 2 | 🟠 مهم | `DecreeLineModal.razor` | مبلغ صفر بدون هشدار ذخیره می‌شد اگر فیلد خالی بود → رفع: guard روی `TryParse` + `amt <= 0` |
| 3 | 🟠 مهم | `ItemTemplateLineModal.razor` | همان مشکل مبلغ صفر در قالب‌ها |
| 4 | 🟠 امنیتی | `Pay2EmployeesController.cs` | گارد از EMP_ID استفاده می‌کرد نه DEC_ID → false positive برای احکام تأییدنشده همان کارمند |
| 5 | 🟠 امنیتی | `Pay2EmployeesController.cs` | گارد از تاریخ‌های client استفاده می‌کرد → قابل bypass از طریق دستکاری |
| 6 | 🟠 امنیتی | `Pay2EmployeesController.cs` | two-step bypass: unlock → backdate → re-confirm بدون چک |
| 7 | 🟡 migration | `008_DecreeLineAmountDecimal.sql` | constraint بدون `parent_object_id` → خطر drop constraint روی جدول دیگر |
| 8 | 🟡 کد | `ItemTemplateLineModal.razor` | `(long)decimal.Truncate` → داده قدیمی اعشاری را truncate می‌کرد و ناسازگار با DecreeLineModal بود |
| 9 | 🟡 کد | دو مودال | `LoadShiftModeAsync` و `IsShiftPctLine` در هر دو کامپوننت تکرار شده بود |
| 10 | 🟡 performance | دو مودال | `GetItemDefsLookupAsync` یک HTTP call اضافی بود — حذف و projection از `FullItemDefs` |

---

## رفتار جدید

| وضعیت حکم | نتیجه |
|-----------|--------|
| تأیید شده، هنوز فیش قطعی نشده | ✅ قابل unlock — آیتم‌های ریالی قابل ویرایش |
| تأیید شده، فیش قطعی صادر شده | ❌ خطا — باید حکم اصلاحی جدید صادر شود |
| تأیید شده، unlock شده و backdated به ماه قطعی | ❌ خطا در re-confirmation |
| هنوز تأیید نشده | دکمه لغو تأیید نمایش داده نمی‌شود |

---

## فایل‌های تغییریافته

| فایل | تغییر |
|------|--------|
| `DecreeModal.razor` | دکمه لغو تأیید، متد UnlockDecree، manual property copy، LoadData موازی |
| `DecreeLineModal.razor` | بنر راهنما، guard مبلغ، حذف تکرار، حذف HTTP call اضافی |
| `ItemTemplateLineModal.razor` | guard مبلغ، اصلاح cast، حذف تکرار، حذف HTTP call اضافی |
| `Pay2SettingsApiService.cs` | متدهای `GetShiftModeAsync` و `IsShiftPctItem` مشترک |
| `Pay2EmployeesController.cs` | گارد چندلایه: wasConfirmed، DB dates، re-confirmation guard |
| `PAY2_Procedures_v6.sql` | `ROUND` قبل از `CAST AS BIGINT` برای حق شیفت اعشاری |
| `ScriptSqly.cs` | همان اصلاح SP |
| `006_Pay2_HourlyCalcBasis.sql` | همان اصلاح SP |
| `008_DecreeLineAmountDecimal.sql` | اصلاح scope constraint با `parent_object_id` |

---

## چک‌لیست تست

- [ ] حکم ایجاد و تأیید کن
- [ ] «لغو تأیید» بزن → باید موفق باشد
- [ ] آیتم ریالی را ویرایش کن
- [ ] حق شیفت 12.5% تعریف کن و حقوق محاسبه کن → مبلغ نباید truncate شود
- [ ] حقوق آن ماه را قطعی کن
- [ ] سعی کن همان حکم را unlock کنی → باید خطا بدهد
- [ ] unlock کن (بدون فیش قطعی) → تاریخ را به ماه قطعی‌شده تغییر بده → re-confirm → باید خطا بدهد
- [ ] مبلغ فیلد را خالی بگذار و Save بزن → باید هشدار بدهد نه ذخیره کند

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2JcPjHycDbWamBykk4SEy