### PR TITLE
[CLOSED] feat: لغو تأیید حکم کارگزینی (Unlock Decree)

### DIFF
--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
@@ -278,7 +278,11 @@
             Lines = linesTask.Result;
             FullItemDefs = fullDefsTask.Result;
             _shiftMode = shiftModeTask.Result;
-            ItemDefs = FullItemDefs.Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? "")).ToList();
+            var _deductionCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "INS_DED", "TAX_DED", "LOAN_DED", "ADVANCE_DED" };
+            ItemDefs = FullItemDefs
+                .Where(d => d.IS_ACTIVE && (d.ITEM_TYPE == 1 || d.ITEM_TYPE == 2) && !_deductionCodes.Contains(d.ITEM_CODE ?? ""))
+                .Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? ""))
+                .ToList();
         }
         catch (Exception ex)
         {

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
@@ -34,10 +34,15 @@
                 <!-- 🚀 پیام اطلاع‌رسانی به کاربر (UX) -->
                 @if (IsDecreeConfirmed)
                 {
-                    <div style="background: var(--p2-warning-bg); border: 1px solid var(--p2-warning-border); border-radius: var(--p2-radius-md); padding: 12px 16px; margin-bottom: 16px; flex-shrink: 0; display:flex; gap:10px; align-items:center;">
-                        <i class="bi bi-shield-lock" style="color: var(--p2-warning-text); font-size: 18px;"></i>
-                        <span style="font-size:13px; color: var(--p2-text-main);">
-                            این حکم <b>تأیید نهایی</b> شده است. برای حفظ یکپارچگی اطلاعات، امکان افزودن، ویرایش یا حذف آیتم‌های ریالی وجود ندارد.
+                    <div style="background: var(--p2-warning-bg); border: 1px solid var(--p2-warning-border); border-radius: var(--p2-radius-md); padding: 12px 16px; margin-bottom: 16px; flex-shrink: 0; display:flex; gap:10px; align-items:flex-start;">
+                        <i class="bi bi-shield-lock" style="color: var(--p2-warning-text); font-size: 18px; margin-top: 2px;"></i>
+                        <span style="font-size:13px; color: var(--p2-text-main); line-height: 1.8;">
+                            این حکم <b>تأیید نهایی</b> شده است و آیتم‌های آن قابل تغییر نیستند.<br />
+                            <span style="color: var(--p2-text-muted);">
+                                برای ویرایش، از صفحه قبل روی دکمه
+                                <b style="color: var(--p2-warning-text);"><i class="bi bi-unlock"></i> لغو تأیید</b>
+                                کلیک کنید — در صورتی که حقوق این دوره قطعی نشده باشد، حکم باز می‌شود.
+                            </span>
                         </span>
                     </div>
                 }
@@ -264,18 +269,16 @@
         try
         {
             // منتظر می‌مانیم تا هم لیست تعاریف آیتم‌ها و هم اقلام ریالی این حکم به طور کامل لود شوند
-            // چهار فراخوانی مستقل به صورت موازی اجرا می‌شوند تا باز شدن مودال سریع‌تر باشد
-            var itemDefsTask = EmployeeApi.GetItemDefsLookupAsync();
             var linesTask = EmployeeApi.GetDecreeLinesAsync(DecreeId);
             var fullDefsTask = ItemDefApi.GetItemDefsAsync();
-            var shiftModeTask = LoadShiftModeAsync();
+            var shiftModeTask = SettingsApi.GetShiftModeAsync();
 
-            await Task.WhenAll(itemDefsTask, linesTask, fullDefsTask, shiftModeTask);
+            await Task.WhenAll(linesTask, fullDefsTask, shiftModeTask);
 
-            ItemDefs = itemDefsTask.Result;
             Lines = linesTask.Result;
             FullItemDefs = fullDefsTask.Result;
             _shiftMode = shiftModeTask.Result;
+            ItemDefs = FullItemDefs.Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? "")).ToList();
         }
         catch (Exception ex)
         {
@@ -322,22 +325,8 @@
         ShiftHint = null;
     }
 
-    bool IsShiftPctLine(Pay2DecreeLineDto line)
-    {
-        if (string.Equals(_shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase)) return false;
-        var def = FullItemDefs.FirstOrDefault(d => d.ITEM_ID == line.ITEM_ID);
-        return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
-    }
-
-    async Task<string> LoadShiftModeAsync()
-    {
-        try
-        {
-            var configs = await SettingsApi.GetConfigsAsync();
-            return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
-        }
-        catch { return "PCT"; }
-    }
+    bool IsShiftPctLine(Pay2DecreeLineDto line) =>
+        Pay2SettingsApiService.IsShiftPctItem(_shiftMode, FullItemDefs, line.ITEM_ID);
 
     // منطق مشترک «درصد × حقوق پایه ماهیانه» برای هر دو کمک‌محاسبه (شیفت و عمومی)
     (long? Computed, string Hint) CalcPercentOfMonthly(decimal pct)
@@ -426,10 +415,13 @@
             Snackbar.Add("انتخاب آیتم حقوقی الزامی است.", MudBlazor.Severity.Warning); return;
         }
 
-        decimal.TryParse(CurrentAmountStr?.Replace(",", ""),
-            System.Globalization.NumberStyles.Number,
-            System.Globalization.CultureInfo.InvariantCulture,
-            out decimal amt);
+        if (!decimal.TryParse(CurrentAmountStr?.Replace(",", ""),
+                System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out decimal amt) || amt <= 0)
+        {
+            Snackbar.Add("مبلغ وارد شده معتبر نیست.", MudBlazor.Severity.Warning); return;
+        }
 
         CurrentLine.DEC_ID = DecreeId;
         CurrentLine.AMOUNT = amt;

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor
@@ -278,11 +278,7 @@
             Lines = linesTask.Result;
             FullItemDefs = fullDefsTask.Result;
             _shiftMode = shiftModeTask.Result;
-            var _deductionCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "INS_DED", "TAX_DED", "LOAN_DED", "ADVANCE_DED" };
-            ItemDefs = FullItemDefs
-                .Where(d => d.IS_ACTIVE && (d.ITEM_TYPE == 1 || d.ITEM_TYPE == 2) && !_deductionCodes.Contains(d.ITEM_CODE ?? ""))
-                .Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? ""))
-                .ToList();
+            ItemDefs = Pay2SettingsApiService.FilterEditableItemDefs(FullItemDefs);
         }
         catch (Exception ex)
         {

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor
@@ -123,10 +123,19 @@
                                         <i class="bi bi-square" style="color:var(--p2-text-light); font-size:16px;"></i>
                                     }
                                 </td>
-                                <td style="text-align:center; min-width: 250px;">
+                                <td style="text-align:center; min-width: 280px;">
                                     <button class="btn-ghost-pay2" style="color:#8b5cf6;" @onclick="() => OpenDecreeLines(dec)">آیتم‌های ریالی</button>
-                                    <button class="btn-ghost-pay2 p2-text-primary" @onclick="() => EditDecree(dec)">ویرایش</button>
-                                    <button class="btn-ghost-pay2 p2-text-danger" @onclick="() => DeleteDecree(dec)">حذف</button>
+                                    @if (dec.IS_CONFIRMED)
+                                    {
+                                        <button class="btn-ghost-pay2" style="color: var(--p2-warning-text);" @onclick="() => UnlockDecree(dec)" title="لغو تأیید نهایی — فقط اگر حقوق قطعی نشده باشد">
+                                            <i class="bi bi-unlock"></i> لغو تأیید
+                                        </button>
+                                    }
+                                    else
+                                    {
+                                        <button class="btn-ghost-pay2 p2-text-primary" @onclick="() => EditDecree(dec)">ویرایش</button>
+                                        <button class="btn-ghost-pay2 p2-text-danger" @onclick="() => DeleteDecree(dec)">حذف</button>
+                                    }
                                 </td>
                             </tr>
                         }
@@ -195,8 +204,11 @@
     {
         try
         {
-            Templates = await EmployeeApi.GetTemplatesLookupAsync();
-            Decrees = await EmployeeApi.GetDecreesAsync(EmployeeId);
+            var templatesTask = EmployeeApi.GetTemplatesLookupAsync();
+            var decreesTask = EmployeeApi.GetDecreesAsync(EmployeeId);
+            await Task.WhenAll(templatesTask, decreesTask);
+            Templates = templatesTask.Result;
+            Decrees = decreesTask.Result;
         }
         catch (Exception ex) { Snackbar.Add(ex.Message, MudBlazor.Severity.Error); }
     }
@@ -283,6 +295,38 @@
     async Task CloseDecreeLineModal()
     {
         ShowDecreeLineModal = false;
+    }
+
+    async Task UnlockDecree(Pay2DecreeDto dec)
+    {
+        var parameters = new MudBlazor.DialogParameters
+        {
+            ["Title"] = "لغو تأیید حکم",
+            ["ContentText"] = $"آیا از لغو تأیید حکم (شروع اجرا: {dec.EFF_FROM}) اطمینان دارید؟\nدر صورتی که حقوق این دوره قطعی نشده باشد، حکم برای ویرایش باز می‌شود.",
+            ["ConfirmButtonText"] = "بله، لغو تأیید",
+            ["CancelButtonText"] = "انصراف"
+        };
+        var options = new MudBlazor.DialogOptions { CloseButton = false, MaxWidth = MudBlazor.MaxWidth.ExtraSmall };
+        var dialog = DialogService.Show<Safir.Client.Shared.ConfirmDialog>("لغو تأیید", parameters, options);
+        var result = await dialog.Result;
+
+        if (!result.Cancelled)
+        {
+            try
+            {
+                var toUnlock = new Pay2DecreeDto
+                {
+                    DEC_ID = dec.DEC_ID, EMP_ID = dec.EMP_ID, WS_ID = dec.WS_ID,
+                    ISSUED_DATE = dec.ISSUED_DATE, EFF_FROM = dec.EFF_FROM, EFF_TO = dec.EFF_TO,
+                    EDU_LEVEL = dec.EDU_LEVEL, MARITAL = dec.MARITAL, IS_MANAGER = dec.IS_MANAGER,
+                    TMPL_ID = dec.TMPL_ID, NOTES = dec.NOTES, IS_CONFIRMED = false
+                };
+                await EmployeeApi.SaveDecreeAsync(toUnlock);
+                Snackbar.Add("تأیید حکم با موفقیت لغو شد. اکنون می‌توانید آیتم‌های ریالی را ویرایش کنید.", MudBlazor.Severity.Success);
+                await LoadData();
+            }
+            catch (Exception ex) { Snackbar.Add(ex.Message, MudBlazor.Severity.Error); }
+        }
     }
 
     async Task Close() => await OnClose.InvokeAsync();

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
@@ -164,12 +164,8 @@
 
     bool IsShiftPctItem => IsShiftPctLine(CurrentLine);
 
-    bool IsShiftPctLine(Pay2ItemTmplLineDto line)
-    {
-        if (string.Equals(_shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase)) return false;
-        var def = FullItemDefs.FirstOrDefault(d => d.ITEM_ID == line.ITEM_ID);
-        return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
-    }
+    bool IsShiftPctLine(Pay2ItemTmplLineDto line) =>
+        Pay2SettingsApiService.IsShiftPctItem(_shiftMode, FullItemDefs, line.ITEM_ID);
 
     List<LookupDto<int>> OverrideOptions = new() { new(3, "طبق تعریف پایه"), new(1, "مشمول"), new(2, "معاف") };
     List<LookupDto<int>> BasisOptions = new() { new(9, "طبق تعریف پایه"), new(1, "روزانه"), new(2, "ماهیانه"), new(3, "ساعتی") };
@@ -194,17 +190,16 @@
     {
         try
         {
-            var itemDefsTask = EmployeeApi.GetItemDefsLookupAsync();
             var linesTask = EmployeeApi.GetTemplateLinesAsync(MasterTemplateId);
             var fullDefsTask = ItemDefApi.GetItemDefsAsync();
-            var shiftModeTask = LoadShiftModeAsync();
+            var shiftModeTask = SettingsApi.GetShiftModeAsync();
 
-            await Task.WhenAll(itemDefsTask, linesTask, fullDefsTask, shiftModeTask);
+            await Task.WhenAll(linesTask, fullDefsTask, shiftModeTask);
 
-            ItemDefs = itemDefsTask.Result;
             Lines = linesTask.Result;
             FullItemDefs = fullDefsTask.Result;
             _shiftMode = shiftModeTask.Result;
+            ItemDefs = FullItemDefs.Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? "")).ToList();
         }
         catch (Exception ex) { Console.WriteLine(ex.Message); }
         finally
@@ -212,16 +207,6 @@
             _isDataLoaded = true;
             StateHasChanged();
         }
-    }
-
-    async Task<string> LoadShiftModeAsync()
-    {
-        try
-        {
-            var configs = await SettingsApi.GetConfigsAsync();
-            return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
-        }
-        catch { return "PCT"; }
     }
 
     void ResetForm()
@@ -250,7 +235,7 @@
         };
         AmountStr = IsShiftPctItem
             ? CurrentLine.DEF_AMOUNT.ToString(System.Globalization.CultureInfo.InvariantCulture)
-            : ((long)decimal.Truncate(CurrentLine.DEF_AMOUNT)).ToString();
+            : CurrentLine.DEF_AMOUNT.ToString("0", System.Globalization.CultureInfo.InvariantCulture);
         IsEditing = true;
     }
 
@@ -260,10 +245,13 @@
         {
             Snackbar.Add("انتخاب آیتم حقوقی الزامی است.", MudBlazor.Severity.Warning); return;
         }
-        decimal.TryParse(AmountStr?.Replace(",", ""),
-            System.Globalization.NumberStyles.Number,
-            System.Globalization.CultureInfo.InvariantCulture,
-            out decimal amt);
+        if (!decimal.TryParse(AmountStr?.Replace(",", ""),
+                System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out decimal amt) || amt <= 0)
+        {
+            Snackbar.Add("مبلغ وارد شده معتبر نیست.", MudBlazor.Severity.Warning); return;
+        }
         CurrentLine.TMPL_ID = MasterTemplateId;
         CurrentLine.DEF_AMOUNT = amt;
         IsSaving = true;

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
@@ -199,7 +199,11 @@
             Lines = linesTask.Result;
             FullItemDefs = fullDefsTask.Result;
             _shiftMode = shiftModeTask.Result;
-            ItemDefs = FullItemDefs.Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? "")).ToList();
+            var _deductionCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "INS_DED", "TAX_DED", "LOAN_DED", "ADVANCE_DED" };
+            ItemDefs = FullItemDefs
+                .Where(d => d.IS_ACTIVE && (d.ITEM_TYPE == 1 || d.ITEM_TYPE == 2) && !_deductionCodes.Contains(d.ITEM_CODE ?? ""))
+                .Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? ""))
+                .ToList();
         }
         catch (Exception ex) { Console.WriteLine(ex.Message); }
         finally

--- a/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
+++ b/Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor
@@ -199,11 +199,7 @@
             Lines = linesTask.Result;
             FullItemDefs = fullDefsTask.Result;
             _shiftMode = shiftModeTask.Result;
-            var _deductionCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "INS_DED", "TAX_DED", "LOAN_DED", "ADVANCE_DED" };
-            ItemDefs = FullItemDefs
-                .Where(d => d.IS_ACTIVE && (d.ITEM_TYPE == 1 || d.ITEM_TYPE == 2) && !_deductionCodes.Contains(d.ITEM_CODE ?? ""))
-                .Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? ""))
-                .ToList();
+            ItemDefs = Pay2SettingsApiService.FilterEditableItemDefs(FullItemDefs);
         }
         catch (Exception ex) { Console.WriteLine(ex.Message); }
         finally

--- a/Client/Services/Pay2SettingsApiService.cs
+++ b/Client/Services/Pay2SettingsApiService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http.Json;
+using Safir.Shared.Models;
 using Safir.Shared.Models.Salary;
 
 namespace Safir.Client.Services
@@ -46,6 +47,23 @@ namespace Safir.Client.Services
             var res = await _http.PostAsJsonAsync("api/pay2/settings/tax/brackets/copy-year", request);
             if (!res.IsSuccessStatusCode)
                 throw new Exception(await res.Content.ReadAsStringAsync());
+        }
+
+        public async Task<string> GetShiftModeAsync()
+        {
+            try
+            {
+                var configs = await GetConfigsAsync();
+                return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
+            }
+            catch { return "PCT"; }
+        }
+
+        public static bool IsShiftPctItem(string shiftMode, IEnumerable<Pay2ItemDefDto> defs, int itemId)
+        {
+            if (string.Equals(shiftMode, "FIXED", StringComparison.OrdinalIgnoreCase)) return false;
+            var def = defs.FirstOrDefault(d => d.ITEM_ID == itemId);
+            return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/Client/Services/Pay2SettingsApiService.cs
+++ b/Client/Services/Pay2SettingsApiService.cs
@@ -49,14 +49,18 @@ namespace Safir.Client.Services
                 throw new Exception(await res.Content.ReadAsStringAsync());
         }
 
+        private string? _cachedShiftMode;
+
         public async Task<string> GetShiftModeAsync()
         {
+            if (_cachedShiftMode is not null) return _cachedShiftMode;
             try
             {
                 var configs = await GetConfigsAsync();
-                return configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
+                _cachedShiftMode = configs.FirstOrDefault(c => c.CFG_KEY == "SHIFT_MODE")?.CFG_VALUE ?? "PCT";
             }
-            catch { return "PCT"; }
+            catch { _cachedShiftMode = "PCT"; }
+            return _cachedShiftMode;
         }
 
         public static bool IsShiftPctItem(string shiftMode, IEnumerable<Pay2ItemDefDto> defs, int itemId)
@@ -65,5 +69,15 @@ namespace Safir.Client.Services
             var def = defs.FirstOrDefault(d => d.ITEM_ID == itemId);
             return string.Equals(def?.ITEM_CODE, "SHIFT", StringComparison.OrdinalIgnoreCase);
         }
+
+        private static readonly HashSet<string> _editableItemFilter = new(StringComparer.OrdinalIgnoreCase)
+            { "INS_DED", "TAX_DED", "LOAN_DED", "ADVANCE_DED" };
+
+        public static List<LookupDto<int>> FilterEditableItemDefs(IEnumerable<Pay2ItemDefDto> defs) =>
+            defs.Where(d => d.IS_ACTIVE
+                         && (d.ITEM_TYPE == 1 || d.ITEM_TYPE == 2)
+                         && !_editableItemFilter.Contains(d.ITEM_CODE ?? ""))
+                .Select(d => new LookupDto<int>(d.ITEM_ID, d.ITEM_NAME ?? ""))
+                .ToList();
     }
 }

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -25,6 +25,9 @@ namespace Safir.Server.Controllers
             _cache = cache;
         }
 
+        private static readonly HashSet<string> _autoDeductionCodes = new(StringComparer.OrdinalIgnoreCase)
+            { "INS_DED", "TAX_DED", "LOAN_DED", "ADVANCE_DED" };
+
         private long DecrementShamsiDate(long shamsiDate)
         {
             int y = (int)(shamsiDate / 10000);
@@ -194,11 +197,14 @@ namespace Safir.Server.Controllers
                     }
                     else // ویرایش
                     {
-                        var dbDecree = await conn.QuerySingleAsync(
+                        var dbDecree = await conn.QuerySingleOrDefaultAsync(
                             "SELECT IS_CONFIRMED, EMP_ID FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID",
-                            new { decree.DEC_ID }, tran);
+                            new { decree.DEC_ID }, tran)
+                            ?? throw new KeyNotFoundException();
                         bool wasConfirmed = (bool)dbDecree.IS_CONFIRMED;
                         int dbEmpId = (int)dbDecree.EMP_ID;
+                        if (dbEmpId != decree.EMP_ID)
+                            throw new UnauthorizedAccessException();
 
                         // فقط احکام تأییدشده مسدود می‌شوند — احکام تأییدنشده هرگز در حقوق استفاده نشده‌اند
                         // از تاریخ‌های ذخیره‌شده در DB استفاده می‌شود تا bypass از طریق دستکاری تاریخ ممکن نباشد
@@ -267,6 +273,8 @@ namespace Safir.Server.Controllers
 
                 return Ok(decId);
             }
+            catch (KeyNotFoundException) { return NotFound("حکم مورد نظر یافت نشد."); }
+            catch (UnauthorizedAccessException) { return Forbid(); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
             catch (Exception ex) { return StatusCode(500, "خطای سیستمی: " + ex.Message); }
         }
@@ -289,9 +297,10 @@ namespace Safir.Server.Controllers
             {
                 await _db.ExecuteInTransactionAsync(async (conn, tran) =>
                 {
-                    // 🚀 گارد امنیتی سطح ۳: حکم تایید شده قابل حذف فیزیکی نیست!
-                    bool isConfirmed = await conn.QuerySingleAsync<bool>("SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @decId", new { decId }, tran);
-                    if (isConfirmed)
+                    var decRow = await conn.QuerySingleOrDefaultAsync(
+                        "SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @decId", new { decId }, tran)
+                        ?? throw new KeyNotFoundException();
+                    if ((bool)decRow.IS_CONFIRMED)
                         throw new InvalidOperationException("این حکم تأیید نهایی شده است. برای حذف آن، ابتدا باید آن را از حالت تایید خارج کنید.");
 
                     await conn.ExecuteAsync("DELETE FROM PAY2_DECREE_LINE WHERE DEC_ID = @decId", new { decId }, tran);
@@ -299,6 +308,7 @@ namespace Safir.Server.Controllers
                 });
                 return Ok();
             }
+            catch (KeyNotFoundException) { return NotFound("حکم مورد نظر یافت نشد."); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
             catch (Exception ex) { return StatusCode(500, ex.Message); }
         }
@@ -339,10 +349,25 @@ namespace Safir.Server.Controllers
             {
                 await _db.ExecuteInTransactionAsync(async (conn, tran) =>
                 {
-                    // 🚀 گارد امنیتی سطح ۲: آیا هدر این حکم قفل است؟
-                    bool isConfirmed = await conn.QuerySingleAsync<bool>("SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID", new { line.DEC_ID }, tran);
-                    if (isConfirmed)
+                    var decHeader = await conn.QuerySingleOrDefaultAsync(
+                        "SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID", new { line.DEC_ID }, tran)
+                        ?? throw new KeyNotFoundException();
+                    if ((bool)decHeader.IS_CONFIRMED)
                         throw new InvalidOperationException("این حکم قفل (تأیید نهایی) شده است! برای افزودن یا تغییر مبالغ، باید ابتدا در صفحه قبل، تیک تایید این حکم را بردارید.");
+
+                    // اعتبارسنجی آیتم: فعال بودن، نوع پرداختی، عدم کسر اتوماتیک
+                    var itemInfo = await conn.QuerySingleOrDefaultAsync(
+                        "SELECT ITEM_TYPE, ITEM_CODE, IS_ACTIVE FROM PAY2_ITEM_DEF WHERE ITEM_ID = @ITEM_ID",
+                        new { line.ITEM_ID }, tran)
+                        ?? throw new InvalidOperationException("آیتم حقوقی مورد نظر یافت نشد.");
+                    if (!(bool)itemInfo.IS_ACTIVE)
+                        throw new InvalidOperationException("آیتم حقوقی مورد نظر غیرفعال است.");
+                    byte itemType = (byte)itemInfo.ITEM_TYPE;
+                    if (itemType != 1 && itemType != 2)
+                        throw new InvalidOperationException("فقط آیتم‌های پرداختی (نوع ۱ و ۲) در احکام مجاز هستند.");
+                    string? itemCode = (string?)itemInfo.ITEM_CODE;
+                    if (itemCode != null && _autoDeductionCodes.Contains(itemCode))
+                        throw new InvalidOperationException("آیتم‌های کسر اتوماتیک را نمی‌توان به صورت دستی به حکم اضافه کرد.");
 
                     // اعتبارسنجی: مقدار اعشاری فقط برای آیتم حق شیفت درصدی مجاز است
                     if (line.AMOUNT != Math.Truncate(line.AMOUNT))
@@ -372,6 +397,7 @@ namespace Safir.Server.Controllers
                 });
                 return Ok();
             }
+            catch (KeyNotFoundException) { return NotFound("حکم مورد نظر یافت نشد."); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
             catch (Exception ex) { return StatusCode(500, ex.Message); }
         }
@@ -384,9 +410,10 @@ namespace Safir.Server.Controllers
             {
                 await _db.ExecuteInTransactionAsync(async (conn, tran) =>
                 {
-                    // 🚀 گارد امنیتی سطح ۲: آیا هدر این حکم قفل است؟
-                    bool isConfirmed = await conn.QuerySingleAsync<bool>("SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @decId", new { decId }, tran);
-                    if (isConfirmed)
+                    var decRow = await conn.QuerySingleOrDefaultAsync(
+                        "SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @decId", new { decId }, tran)
+                        ?? throw new KeyNotFoundException();
+                    if ((bool)decRow.IS_CONFIRMED)
                         throw new InvalidOperationException("این حکم قفل (تأیید نهایی) شده است! اجازه حذف مبالغ آن را ندارید.");
 
                     const string sql = "DELETE FROM PAY2_DECREE_LINE WHERE DEC_ID=@decId AND ITEM_ID=@itemId";
@@ -394,6 +421,7 @@ namespace Safir.Server.Controllers
                 });
                 return Ok();
             }
+            catch (KeyNotFoundException) { return NotFound("حکم مورد نظر یافت نشد."); }
             catch (InvalidOperationException ex) { return BadRequest(ex.Message); }
             catch (Exception ex) { return StatusCode(500, ex.Message); }
         }

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -194,7 +194,11 @@ namespace Safir.Server.Controllers
                     }
                     else // ویرایش
                     {
-                        bool wasConfirmed = await conn.QuerySingleAsync<bool>("SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID", new { decree.DEC_ID }, tran);
+                        var dbDecree = await conn.QuerySingleAsync(
+                            "SELECT IS_CONFIRMED, EMP_ID FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID",
+                            new { decree.DEC_ID }, tran);
+                        bool wasConfirmed = (bool)dbDecree.IS_CONFIRMED;
+                        int dbEmpId = (int)dbDecree.EMP_ID;
 
                         // فقط احکام تأییدشده مسدود می‌شوند — احکام تأییدنشده هرگز در حقوق استفاده نشده‌اند
                         // از تاریخ‌های ذخیره‌شده در DB استفاده می‌شود تا bypass از طریق دستکاری تاریخ ممکن نباشد
@@ -208,10 +212,10 @@ namespace Safir.Server.Controllers
                         WHERE R.STATUS >= 2
                           AND (P.PERIOD_DATE / 100) >= (D.EFF_FROM / 100)
                           AND (D.EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (D.EFF_TO / 100))
-                          AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
+                          AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = D.EMP_ID)";
 
                             int usedInFinalRun = await conn.QuerySingleAsync<int>(
-                                checkUsageSql, new { DEC_ID = currentDecId, EMP_ID = decree.EMP_ID }, tran);
+                                checkUsageSql, new { DEC_ID = currentDecId }, tran);
 
                             if (usedInFinalRun > 0)
                                 throw new InvalidOperationException("این حکم در ماه‌های گذشته جهت صدور حقوق قطعی استفاده شده است. امکان ویرایش یا لغو تایید آن به هیچ وجه وجود ندارد. برای تغییر حقوق، باید یک حکم جدید صادر کنید.");
@@ -241,7 +245,7 @@ namespace Safir.Server.Controllers
 
                                 int reconfirmConflict = await conn.QuerySingleAsync<int>(
                                     checkReconfirmSql,
-                                    new { EFF_FROM = decree.EFF_FROM, EFF_TO = (long?)decree.EFF_TO, EMP_ID = decree.EMP_ID },
+                                    new { EFF_FROM = decree.EFF_FROM, EFF_TO = (long?)decree.EFF_TO, EMP_ID = dbEmpId },
                                     tran);
 
                                 if (reconfirmConflict > 0)

--- a/Server/Controllers/Pay2EmployeesController.cs
+++ b/Server/Controllers/Pay2EmployeesController.cs
@@ -162,24 +162,6 @@ namespace Safir.Server.Controllers
                 {
                     int currentDecId = decree.DEC_ID;
 
-                    // 🚀 گارد امنیتی سطح ۱: بررسی تداخل با فیش‌های قطعی‌شده
-                    if (currentDecId > 0)
-                    {
-                        string checkUsageSql = @"
-                    SELECT COUNT(1) 
-                    FROM PAY2_RUN R
-                    INNER JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
-                    WHERE R.STATUS >= 2 
-                      -- 🛠 رفع باگ مقایسه تاریخ: تبدیل هر دو تاریخ به YYYYMM
-                      AND (P.PERIOD_DATE / 100) >= (SELECT (EFF_FROM / 100) FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID)
-                      AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
-
-                        int usedInFinalRun = await conn.QuerySingleAsync<int>(checkUsageSql, new { DEC_ID = currentDecId, EMP_ID = decree.EMP_ID }, tran);
-
-                        if (usedInFinalRun > 0)
-                            throw new InvalidOperationException("این حکم در ماه‌های گذشته جهت صدور حقوق قطعی استفاده شده است. امکان ویرایش یا لغو تایید آن به هیچ وجه وجود ندارد. برای تغییر حقوق، باید یک حکم جدید صادر کنید.");
-                    }
-
                     if (currentDecId == 0) // درج جدید
                     {
                         // بستن هوشمند تاریخ حکم قبلی
@@ -214,6 +196,27 @@ namespace Safir.Server.Controllers
                     {
                         bool wasConfirmed = await conn.QuerySingleAsync<bool>("SELECT IS_CONFIRMED FROM PAY2_DECREE WHERE DEC_ID = @DEC_ID", new { decree.DEC_ID }, tran);
 
+                        // فقط احکام تأییدشده مسدود می‌شوند — احکام تأییدنشده هرگز در حقوق استفاده نشده‌اند
+                        // از تاریخ‌های ذخیره‌شده در DB استفاده می‌شود تا bypass از طریق دستکاری تاریخ ممکن نباشد
+                        if (wasConfirmed)
+                        {
+                            const string checkUsageSql = @"
+                        SELECT COUNT(1)
+                        FROM PAY2_RUN R
+                        INNER JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
+                        INNER JOIN PAY2_DECREE D ON D.DEC_ID = @DEC_ID
+                        WHERE R.STATUS >= 2
+                          AND (P.PERIOD_DATE / 100) >= (D.EFF_FROM / 100)
+                          AND (D.EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (D.EFF_TO / 100))
+                          AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
+
+                            int usedInFinalRun = await conn.QuerySingleAsync<int>(
+                                checkUsageSql, new { DEC_ID = currentDecId, EMP_ID = decree.EMP_ID }, tran);
+
+                            if (usedInFinalRun > 0)
+                                throw new InvalidOperationException("این حکم در ماه‌های گذشته جهت صدور حقوق قطعی استفاده شده است. امکان ویرایش یا لغو تایید آن به هیچ وجه وجود ندارد. برای تغییر حقوق، باید یک حکم جدید صادر کنید.");
+                        }
+
                         // 🛠 رفع بن‌بست منطقی: فقط زمانی آپدیت را به NOTES محدود کن که کاربر هنوز می‌خواهد حکم تایید شده بماند.
                         // اگر کاربر تیک تایید را در UI برداشته باشد (decree.IS_CONFIRMED == false)، باید اجازه دهیم کل حکم از قفل خارج شود.
                         if (wasConfirmed && decree.IS_CONFIRMED)
@@ -223,10 +226,32 @@ namespace Safir.Server.Controllers
                         }
                         else
                         {
+                            // گارد تأیید مجدد: احکامی که پس از unlock دوباره تأیید می‌شوند
+                            // باید تاریخ‌های ورودی بررسی شود تا مانع backdating به ماه‌های قطعی‌شده شویم
+                            if (!wasConfirmed && decree.IS_CONFIRMED)
+                            {
+                                const string checkReconfirmSql = @"
+                        SELECT COUNT(1)
+                        FROM PAY2_RUN R
+                        INNER JOIN PAY2_PERIOD P ON R.PER_ID = P.PER_ID
+                        WHERE R.STATUS >= 2
+                          AND (P.PERIOD_DATE / 100) >= (@EFF_FROM / 100)
+                          AND (@EFF_TO IS NULL OR (P.PERIOD_DATE / 100) <= (@EFF_TO / 100))
+                          AND R.RUN_ID IN (SELECT RUN_ID FROM PAY2_RUN_LINE WHERE EMP_ID = @EMP_ID)";
+
+                                int reconfirmConflict = await conn.QuerySingleAsync<int>(
+                                    checkReconfirmSql,
+                                    new { EFF_FROM = decree.EFF_FROM, EFF_TO = (long?)decree.EFF_TO, EMP_ID = decree.EMP_ID },
+                                    tran);
+
+                                if (reconfirmConflict > 0)
+                                    throw new InvalidOperationException("بازه زمانی این حکم با ماه‌هایی که حقوق آنها قطعی شده تداخل دارد. لطفاً بازه تاریخی را اصلاح کنید یا با دوره‌های تأیید نشده کار کنید.");
+                            }
+
                             const string updateSql = @"
-                        UPDATE PAY2_DECREE 
-                        SET ISSUED_DATE=@ISSUED_DATE, EFF_FROM=@EFF_FROM, EFF_TO=@EFF_TO, 
-                            EDU_LEVEL=@EDU_LEVEL, MARITAL=@MARITAL, IS_MANAGER=@IS_MANAGER, 
+                        UPDATE PAY2_DECREE
+                        SET ISSUED_DATE=@ISSUED_DATE, EFF_FROM=@EFF_FROM, EFF_TO=@EFF_TO,
+                            EDU_LEVEL=@EDU_LEVEL, MARITAL=@MARITAL, IS_MANAGER=@IS_MANAGER,
                             IS_CONFIRMED=@IS_CONFIRMED, NOTES=@NOTES
                         WHERE DEC_ID=@DEC_ID";
                             await conn.ExecuteAsync(updateSql, decree, tran);

--- a/Server/Info/PAY2_Procedures_v6.sql
+++ b/Server/Info/PAY2_Procedures_v6.sql
@@ -238,6 +238,7 @@ BEGIN
                         BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
                             -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
+                            -- NOTE: این منطق در Server/Scripts/006_Pay2_HourlyCalcBasis.sql هم وجود دارد؛ تغییر باید در هر دو فایل اعمال شود
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
                             SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;

--- a/Server/Info/PAY2_Procedures_v6.sql
+++ b/Server/Info/PAY2_Procedures_v6.sql
@@ -239,7 +239,7 @@ BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
                             -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
-                            SET @CALC_AMOUNT = CAST(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0 AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;
                     END;
                     ELSE

--- a/Server/Info/ScriptSqly.cs
+++ b/Server/Info/ScriptSqly.cs
@@ -1453,7 +1453,7 @@ BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
                             -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
-                            SET @CALC_AMOUNT = CAST(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0 AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;
                     END;
                     ELSE

--- a/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
+++ b/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
@@ -262,7 +262,7 @@ BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
                             -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
-                            SET @CALC_AMOUNT = CAST(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0 AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;
                     END;
                     ELSE

--- a/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
+++ b/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
@@ -261,6 +261,7 @@ BEGIN
                         BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
                             -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
+                            -- NOTE: این منطق در Server/Info/PAY2_Procedures_v6.sql هم وجود دارد؛ تغییر باید در هر دو فایل اعمال شود
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
                             SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;

--- a/Server/Scripts/008_DecreeLineAmountDecimal.sql
+++ b/Server/Scripts/008_DecreeLineAmountDecimal.sql
@@ -13,7 +13,7 @@ IF EXISTS (
       AND t.name = 'bigint'
 )
 BEGIN
-    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_DL_AMT')
+    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_DL_AMT' AND parent_object_id = OBJECT_ID('dbo.PAY2_DECREE_LINE'))
         ALTER TABLE [dbo].[PAY2_DECREE_LINE] DROP CONSTRAINT [DF_DL_AMT];
 
     ALTER TABLE [dbo].[PAY2_DECREE_LINE]
@@ -37,7 +37,7 @@ IF EXISTS (
       AND t.name = 'bigint'
 )
 BEGIN
-    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TL_AMT')
+    IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TL_AMT' AND parent_object_id = OBJECT_ID('dbo.PAY2_ITEM_TMPL_LINE'))
         ALTER TABLE [dbo].[PAY2_ITEM_TMPL_LINE] DROP CONSTRAINT [DF_TL_AMT];
 
     ALTER TABLE [dbo].[PAY2_ITEM_TMPL_LINE]


### PR DESCRIPTION
## خلاصه

این PR قابلیت **لغو تأیید حکم کارگزینی** را پیاده‌سازی می‌کند و همزمان ۸ اشکال امنیتی و منطقی شناسایی‌شده در code review را رفع می‌کند.

---

## قابلیت جدید: لغو تأیید حکم

احکام کارگزینی پس از تأیید (`IS_CONFIRMED = true`) قابل ویرایش نیستند. این قابلیت به کاربر اجازه می‌دهد در صورت نیاز، تأیید یک حکم را لغو کند تا بتواند آن را ویرایش یا حذف نماید.

### تغییرات UI
- **`DecreeModal.razor`**: دکمه «لغو تأیید» برای احکام تأیید‌شده نمایش داده می‌شود (به جای دکمه‌های ویرایش/حذف که برای این احکام غیرفعال بودند)
- بنر راهنما در `DecreeLineModal.razor` به‌روز شد تا کاربر را به دکمه «لغو تأیید» هدایت کند

### تغییرات سرور — گارد سه‌لایه در `SaveDecree`

| لایه | شرط | عملکرد |
|------|-----|---------|
| ۱+۲ | حکم قبلاً تأیید‌شده بود | تاریخ از DB خوانده می‌شود (نه کلاینت) — اگر حکم در حقوق قطعی استفاده شده، ویرایش ممنوع |
| NOTES-only | تأیید‌شده بود و تأیید‌شده می‌ماند | فقط NOTES به‌روز می‌شود، سایر فیلدها قابل تغییر نیستند |
| ۳ | تأیید‌نشده بود و تأیید می‌شود | بازه تاریخی حکم در حقوق قطعی بررسی می‌شود — جلوگیری از دور زدن دو‌مرحله‌ای قفل |

---

## رفع ۸ اشکال (Code Review)

### 🔴 اشکالات بحرانی

**۱. قطع اعشار حق شیفت در Stored Procedure**
- فایل: `Server/Info/PAY2_Procedures_v6.sql`، `Server/Info/ScriptSqly.cs`، `Server/Scripts/006_Pay2_HourlyCalcBasis.sql`
- مشکل: `CAST(@BASE_SAL * @DAYS * @RATE / 100.0 AS BIGINT)` مقادیر اعشاری را بدون گرد کردن قطع می‌کرد
- رفع: `CAST(ROUND(..., 0) AS BIGINT)` — گرد کردن قبل از تبدیل به BIGINT

**۲. محدوده constraint در migration 008**
- فایل: `Server/Scripts/008_DecreeLineAmountDecimal.sql`
- مشکل: `IF EXISTS (... WHERE name = 'DF_TL_AMT')` ممکن بود constraint جدول دیگری را پیدا کند
- رفع: اضافه کردن `AND parent_object_id = OBJECT_ID('dbo.PAY2_ITEM_TMPL_LINE')`

**۳. دور زدن دو‌مرحله‌ای قفل (Security)**
- فایل: `Server/Controllers/Pay2EmployeesController.cs`
- مشکل: کاربر می‌توانست ابتدا حکم را unlock کند، تاریخ را تغییر دهد، سپس مجدداً تأیید کند
- رفع: گارد لایه ۳ — هنگام re-confirm بازه تاریخی جدید با حقوق قطعی بررسی می‌شود

### 🟡 اشکالات منطقی

**۴. پذیرش بی‌صدای مقدار صفر**
- فایل: `DecreeLineModal.razor`، `ItemTemplateLineModal.razor`
- مشکل: `decimal.TryParse` در صورت شکست، `amt = 0` می‌شد و بدون خطا ذخیره می‌شد
- رفع: اعتبارسنجی `amt <= 0` با نمایش snackbar هشدار

**۵. EditLine: قطع اعشار با Truncate**
- فایل: `ItemTemplateLineModal.razor`
- مشکل: `(long)decimal.Truncate(CurrentLine.DEF_AMOUNT)` مقادیر اعشاری نمایش داده‌شده را قطع می‌کرد
- رفع: `CurrentLine.DEF_AMOUNT.ToString("0", CultureInfo.InvariantCulture)`

**۶. JSON round-trip در UnlockDecree**
- فایل: `DecreeModal.razor`
- مشکل: `JsonSerializer.Deserialize(JsonSerializer.Serialize(dec))` ممکن بود مقادیر را تغییر دهد
- رفع: کپی صریح property به property

### 🔵 بهبود کیفیت کد

**۷. تکرار منطق GetShiftMode + IsShiftPctLine**
- فایل: `Client/Services/Pay2SettingsApiService.cs`
- مشکل: منطق تشخیص آیتم حق شیفت در دو فایل تکرار شده بود
- رفع: استخراج `GetShiftModeAsync()` و `IsShiftPctItem()` به `Pay2SettingsApiService`

**۸. فراخوانی HTTP تکراری GetItemDefsLookupAsync**
- فایل: `DecreeLineModal.razor`، `ItemTemplateLineModal.razor`
- مشکل: `GetItemDefsLookupAsync` و `GetItemDefsAsync` هر دو فراخوانی می‌شدند
- رفع: حذف `GetItemDefsLookupAsync`؛ `ItemDefs` از `FullItemDefs` با LINQ ساخته می‌شود

### ⚡ بهبود کارایی

**بارگذاری موازی در LoadData**
- فایل: `DecreeModal.razor`، `DecreeLineModal.razor`، `ItemTemplateLineModal.razor`
- رفع: استفاده از `Task.WhenAll` برای فراخوانی موازی APIها در بارگذاری اولیه

---

## فایل‌های تغییریافته

| فایل | نوع تغییر |
|------|-----------|
| `Client/Pages/Salary/Tabs/EmployeeComponents/DecreeModal.razor` | قابلیت جدید + Task.WhenAll |
| `Client/Pages/Salary/Tabs/EmployeeComponents/DecreeLineModal.razor` | رفع اشکال + بهبود |
| `Client/Pages/Salary/Tabs/EmployeeComponents/ItemTemplateLineModal.razor` | رفع اشکال + بهبود |
| `Client/Services/Pay2SettingsApiService.cs` | متدهای مشترک جدید |
| `Server/Controllers/Pay2EmployeesController.cs` | گارد سه‌لایه |
| `Server/Info/PAY2_Procedures_v6.sql` | رفع ROUND/CAST |
| `Server/Info/ScriptSqly.cs` | رفع ROUND/CAST |
| `Server/Scripts/006_Pay2_HourlyCalcBasis.sql` | رفع ROUND/CAST |
| `Server/Scripts/008_DecreeLineAmountDecimal.sql` | رفع محدوده constraint |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2JcPjHycDbWamBykk4SEy)_