### PR TITLE
Add payslip PDF generation and preview for salary module

### DIFF
--- a/Client/Components/Reports/PdfPreviewDialog.razor
+++ b/Client/Components/Reports/PdfPreviewDialog.razor
@@ -1,0 +1,108 @@
+@implements IAsyncDisposable
+@inject IJSRuntime JS
+
+@*
+    دیالوگ عمومی و قابل استفادهٔ مجدد برای پیش‌نمایش/چاپ PDF.
+    بایت‌ها را از طریق FetchPdfBytes می‌گیرد، با createPdfBlobUrl به Blob URL تبدیل
+    و در یک iframe نمایش می‌دهد؛ خودِ مرورگر دکمه‌های Print/Zoom/Download را دارد.
+    چون احراز هویت JWT Bearer است، هرگز src مستقیم به api نمی‌دهیم.
+*@
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">
+            <MudIcon Icon="@Icons.Material.Filled.PictureAsPdf" Class="mr-2 mb-n1" Color="Color.Error" />
+            @Title
+        </MudText>
+    </TitleContent>
+    <DialogContent>
+        @if (_isLoading)
+        {
+            <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:75vh;gap:14px;">
+                <MudProgressCircular Indeterminate="true" Size="Size.Large" Color="Color.Primary" />
+                <MudText Typo="Typo.body2">در حال آماده‌سازی فایل PDF...</MudText>
+            </div>
+        }
+        else if (_error != null)
+        {
+            <div style="min-height:30vh;display:flex;align-items:center;justify-content:center;">
+                <MudAlert Severity="Severity.Error" Variant="Variant.Filled" Class="my-4">@_error</MudAlert>
+            </div>
+        }
+        else if (_blobUrl != null)
+        {
+            <iframe src="@_blobUrl" style="width:100%;height:75vh;border:none;" title="@Title"></iframe>
+        }
+    </DialogContent>
+    <DialogActions>
+        @if (_error != null)
+        {
+            <MudButton OnClick="ReloadAsync" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Refresh">تلاش مجدد</MudButton>
+        }
+        <MudButton OnClick="Close">بستن</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; } = default!;
+
+    /// <summary>تابعی که بایت‌های PDF را تأمین می‌کند (مثلاً فراخوانی API با توکن).</summary>
+    [Parameter] public Func<Task<byte[]>>? FetchPdfBytes { get; set; }
+
+    /// <summary>عنوان دیالوگ.</summary>
+    [Parameter] public string Title { get; set; } = "پیش‌نمایش گزارش";
+
+    private bool _isLoading = true;
+    private string? _error;
+    private string? _blobUrl;
+
+    protected override async Task OnInitializedAsync() => await LoadAsync();
+
+    private async Task ReloadAsync()
+    {
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _error = null;
+        await RevokeAsync(); // اگر قبلاً URL ساخته شده بود آزاد کن
+
+        try
+        {
+            if (FetchPdfBytes == null)
+                throw new InvalidOperationException("منبع داده‌ای برای نمایش PDF تعیین نشده است.");
+
+            var bytes = await FetchPdfBytes();
+            if (bytes == null || bytes.Length == 0)
+                throw new InvalidOperationException("فایل PDF خالی است.");
+
+            // byte[] در Blazor به‌صورت Uint8Array به JS منتقل می‌شود
+            _blobUrl = await JS.InvokeAsync<string>("createPdfBlobUrl", bytes);
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task RevokeAsync()
+    {
+        if (_blobUrl != null)
+        {
+            try { await JS.InvokeVoidAsync("revokePdfBlobUrl", _blobUrl); }
+            catch { /* در زمان teardown ممکن است JS در دسترس نباشد */ }
+            _blobUrl = null;
+        }
+    }
+
+    private void Close() => MudDialog.Close(DialogResult.Ok(true));
+
+    public async ValueTask DisposeAsync() => await RevokeAsync();
+}

--- a/Client/Pages/Salary/Tabs/PayrollTab.razor
+++ b/Client/Pages/Salary/Tabs/PayrollTab.razor
@@ -1,5 +1,6 @@
 ﻿@using Safir.Shared.Models.Salary
 @using Safir.Shared.Models
+@using Safir.Client.Components.Reports
 @inject Safir.Client.Services.Pay2RunApiService RunApi
 @inject Safir.Client.Services.Pay2AttendanceApiService AttApi
 @inject Safir.Client.Services.Pay2WorkshopApiService WorkshopApi
@@ -290,6 +291,7 @@
                                 <th style="text-align:left;">مالیات</th>
                                 <th style="text-align:left; color:#ef4444;">مساعده/وام/سایر کسورات</th>
                                 <th style="text-align:left; color:#059669; font-size:14px; border-right: 2px solid var(--p2-border-light);">خالص پرداختی</th>
+                                <th style="text-align:center; border-right: 2px solid var(--p2-border-light);">عملیات</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -322,6 +324,11 @@
                                         <td class="p2-text-mono" style="text-align:left;">@item.TAX_AMOUNT.ToString("N0")</td>
                                         <td class="p2-text-mono p2-text-danger" style="text-align:left;">@item.TOTAL_DED.ToString("N0")</td>
                                         <td class="p2-text-mono p2-text-success" style="text-align:left; font-weight:900; font-size:15px; background: #f0fdf4; border-right: 2px solid var(--p2-border-light);">@item.NET_PAY.ToString("N0")</td>
+                                        <td style="text-align:center; border-right: 2px solid var(--p2-border-light);">
+                                            <button class="btn-outline-pay2 p2-btn-sm" @onclick="() => OpenPayslip(item)" title="چاپ فیش حقوقی">
+                                                <i class="bi bi-printer"></i> چاپ فیش
+                                            </button>
+                                        </td>
                                     </tr>
                                 </Virtualize>
                             }
@@ -346,6 +353,7 @@
                                     <td class="p2-text-mono" style="text-align:left;">@RunData.Lines.Sum(x => x.TAX_AMOUNT).ToString("N0")</td>
                                     <td class="p2-text-mono p2-text-danger" style="text-align:left;">@RunData.Lines.Sum(x => x.TOTAL_DED).ToString("N0")</td>
                                     <td class="p2-text-mono p2-text-success" style="text-align:left; font-size:16px; border-right: 2px solid var(--p2-border-light);">@RunData.Lines.Sum(x => x.NET_PAY).ToString("N0")</td>
+                                    <td style="border-right: 2px solid var(--p2-border-light);"></td>
                                 </tr>
                             }
                         </tfoot>
@@ -625,8 +633,34 @@
             }
             finally 
             { 
-                IsProcessing = false; 
+                IsProcessing = false;
             }
         }
+    }
+
+    // باز کردن پیش‌نمایش/چاپ فیش حقوقی پرسنل در نمایشگر داخلی مرورگر (Blob URL + iframe)
+    void OpenPayslip(Pay2RunLineDto item)
+    {
+        if (CurrentRun == null) return;
+
+        int runId = CurrentRun.RUN_ID;
+        int empId = item.EMP_ID;
+        string fullName = item.FULL_NAME ?? "";
+
+        var parameters = new MudBlazor.DialogParameters
+        {
+            ["Title"] = $"فیش حقوقی - {fullName}",
+            ["FetchPdfBytes"] = (Func<Task<byte[]>>)(() => RunApi.GetPayslipPdfAsync(runId, empId))
+        };
+
+        var options = new MudBlazor.DialogOptions
+        {
+            MaxWidth = MudBlazor.MaxWidth.ExtraExtraLarge,
+            FullWidth = true,
+            CloseButton = true,
+            CloseOnEscapeKey = true
+        };
+
+        DialogService.Show<PdfPreviewDialog>($"فیش حقوقی - {fullName}", parameters, options);
     }
 }

--- a/Client/Services/Pay2RunApiService.cs
+++ b/Client/Services/Pay2RunApiService.cs
@@ -84,6 +84,18 @@ namespace Safir.Client.Services
             if (!res.IsSuccessStatusCode) throw new Exception(await res.Content.ReadAsStringAsync());
         }
 
-
+        // دریافت بایت‌های PDF فیش حقوقی یک پرسنل (برای نمایش در نمایشگر داخلی مرورگر)
+        public async Task<byte[]> GetPayslipPdfAsync(int runId, int empId)
+        {
+            var res = await _http.GetAsync($"api/pay2/run/{runId}/employee/{empId}/payslip");
+            if (!res.IsSuccessStatusCode)
+            {
+                var err = await res.Content.ReadAsStringAsync();
+                throw new Exception(string.IsNullOrWhiteSpace(err)
+                    ? $"خطا در دریافت فیش حقوقی (کد {(int)res.StatusCode})."
+                    : err);
+            }
+            return await res.Content.ReadAsByteArrayAsync();
+        }
     }
 }

--- a/Client/wwwroot/js/interop.js
+++ b/Client/wwwroot/js/interop.js
@@ -70,3 +70,13 @@ window.startP2Resize = function (e, resizerElement, colIndex, isCol1) {
     document.addEventListener('mousemove', mouseMove);
     document.addEventListener('mouseup', mouseUp);
 };
+
+
+// ساخت Blob URL از بایت‌های PDF برای نمایش داخل iframe (نمایشگر داخلی مرورگر)
+window.createPdfBlobUrl = (byteArray) => {
+    const blob = new Blob([byteArray], { type: 'application/pdf' });
+    return URL.createObjectURL(blob);
+};
+
+// آزادسازی Blob URL هنگام بسته شدن نمایشگر (جلوگیری از نشت حافظه)
+window.revokePdfBlobUrl = (url) => { if (url) URL.revokeObjectURL(url); };

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -1,8 +1,12 @@
 ﻿using Dapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using QuestPDF.Fluent;
+using Safir.Server.Reports;
 using Safir.Shared.Interfaces;
 using Safir.Shared.Models.Salary;
+using Safir.Shared.Models.Salary.Reports;
+using Safir.Shared.Utility;
 using System.Security.Claims;
 
 namespace Safir.Server.Controllers
@@ -91,6 +95,146 @@ namespace Safir.Server.Controllers
             public int EMP_ID { get; set; }
             public string ITEM_CODE { get; set; } = "";
             public long AMOUNT { get; set; }
+        }
+
+        // ===================================================================
+        // فیش حقوقی (PDF) — یک پرسنل در یک اجرا
+        // داده آماده می‌شود، PayslipReportDto پر می‌شود و با QuestPDF رندر می‌گردد.
+        // قرارداد داده: مزایا از آیتم‌های نوع ۱و۲ (= GROSS_PAY) و کسورات از فیلدهای
+        // صریح (= TOTAL_DED) تا هیچ آیتمی دوبار شمرده نشود و جمع مزایا − جمع کسورات = خالص.
+        // ===================================================================
+        [HttpGet("{runId:int}/employee/{empId:int}/payslip")]
+        public async Task<IActionResult> GetPayslip(int runId, int empId)
+        {
+            // ۱. هدر فیش (مشخصات پرسنل/دوره/کارگاه + جمع‌های صریح)
+            const string headSql = @"
+                SELECT
+                    RL.RUN_ID, RL.EMP_ID, RL.WORK_DAYS,
+                    RL.GROSS_PAY, RL.INS_BASE, RL.INS_WORKER, RL.TAX_AMOUNT,
+                    RL.LOAN_DED, RL.ADVANCE_DED, RL.OTHER_DED, RL.TOTAL_DED, RL.NET_PAY,
+                    RL.LEAVE_BAL_DAYS, RL.LOAN_BALANCE,
+                    E.EMP_CODE, (E.LAST_NAME + N' ' + E.FIRST_NAME) AS FULL_NAME, E.NATIONAL_CODE,
+                    J.JOB_NAME,
+                    P.PERIOD_DATE,
+                    W.WS_NAME
+                FROM PAY2_RUN_LINE RL WITH (NOLOCK)
+                INNER JOIN PAY2_RUN      R WITH (NOLOCK) ON RL.RUN_ID = R.RUN_ID
+                INNER JOIN PAY2_PERIOD   P WITH (NOLOCK) ON R.PER_ID  = P.PER_ID
+                INNER JOIN PAY2_WORKSHOP W WITH (NOLOCK) ON P.WS_ID   = W.WS_ID
+                INNER JOIN PAY2_EMPLOYEE E WITH (NOLOCK) ON RL.EMP_ID = E.EMP_ID
+                LEFT  JOIN PAY2_JOB      J WITH (NOLOCK) ON E.JOB_ID  = J.JOB_ID
+                WHERE RL.RUN_ID = @runId AND RL.EMP_ID = @empId";
+
+            var head = await _db.DoGetDataSQLAsyncSingle<PayslipHeadRow>(headSql, new { runId, empId });
+            if (head == null)
+                return NotFound("فیش حقوقی برای این پرسنل در این اجرا یافت نشد.");
+
+            // ۲. مزایا = فقط آیتم‌های نوع پرداختی (ITEM_TYPE 1,2)؛ مجموع آن‌ها = GROSS_PAY
+            const string earnSql = @"
+                SELECT I.ITEM_NAME AS Title, D.AMOUNT AS Amount
+                FROM PAY2_RUN_DETAIL D WITH (NOLOCK)
+                INNER JOIN PAY2_ITEM_DEF I WITH (NOLOCK) ON D.ITEM_ID = I.ITEM_ID
+                WHERE D.RUN_ID = @runId AND D.EMP_ID = @empId
+                  AND I.ITEM_TYPE IN (1, 2)
+                  AND D.AMOUNT <> 0
+                ORDER BY I.SORT_ORDER";
+
+            var earnings = (await _db.DoGetDataSQLAsync<PayslipLineDto>(earnSql, new { runId, empId })).ToList();
+
+            // ۳. ساخت DTO آمادهٔ چاپ
+            var dto = new PayslipReportDto
+            {
+                EmployeeName = head.FULL_NAME ?? "",
+                EmployeeCode = head.EMP_CODE ?? "",
+                NationalCode = head.NATIONAL_CODE,
+                JobTitle = head.JOB_NAME,
+                PeriodDate = head.PERIOD_DATE,
+                PeriodTitle = BuildPeriodTitle(head.PERIOD_DATE),
+                WorkshopName = head.WS_NAME ?? "",
+                WorkDays = head.WORK_DAYS,
+                Earnings = earnings,
+                InsBase = head.INS_BASE,
+                LeaveBalanceDays = head.LEAVE_BAL_DAYS,
+                LoanBalance = head.LOAN_BALANCE,
+                NetPay = head.NET_PAY,
+                PrintDate = FormatShamsi(CL_Tarikh.GetCurrentPersianDateAsLong())
+            };
+
+            // کسورات از فیلدهای صریح (مجموعشان = TOTAL_DED) — فقط اقلام غیرصفر
+            void AddDed(string title, long amount)
+            {
+                if (amount != 0)
+                    dto.Deductions.Add(new PayslipLineDto { Title = title, Amount = amount });
+            }
+            AddDed("کسر بیمه کارگر", head.INS_WORKER);
+            AddDed("کسر مالیات", head.TAX_AMOUNT);
+            AddDed("قسط وام", head.LOAN_DED);
+            AddDed("مساعده", head.ADVANCE_DED);
+            AddDed("سایر کسورات", head.OTHER_DED);
+
+            // تعدیلِ گرد کردنِ خالص (اعمال ROUND_MODE در موتور محاسبه) تا اتحاد
+            // «جمع مزایا − جمع کسورات = خالص پرداختیِ رسمی» همیشه دقیق بماند.
+            long rounding = head.NET_PAY - (head.GROSS_PAY - head.TOTAL_DED);
+            if (rounding > 0)
+                dto.Earnings.Add(new PayslipLineDto { Title = "تعدیل (گرد کردن)", Amount = rounding });
+            else if (rounding < 0)
+                dto.Deductions.Add(new PayslipLineDto { Title = "تعدیل (گرد کردن)", Amount = -rounding });
+
+            dto.NetPayInWords = CL_HESABDARI.ALPHANUM(head.NET_PAY) + " ریال";
+
+            // ۴. تولید PDF
+            var env = HttpContext.RequestServices.GetRequiredService<IWebHostEnvironment>();
+            byte[] pdfBytes = new PayslipDocument(dto, env).GeneratePdf();
+
+            return File(pdfBytes, "application/pdf", $"Payslip_{dto.EmployeeCode}.pdf");
+        }
+
+        // کلاس کمکی Dapper برای هدر فیش
+        private class PayslipHeadRow
+        {
+            public int RUN_ID { get; set; }
+            public int EMP_ID { get; set; }
+            public decimal WORK_DAYS { get; set; }
+            public long GROSS_PAY { get; set; }
+            public long INS_BASE { get; set; }
+            public long INS_WORKER { get; set; }
+            public long TAX_AMOUNT { get; set; }
+            public long LOAN_DED { get; set; }
+            public long ADVANCE_DED { get; set; }
+            public long OTHER_DED { get; set; }
+            public long TOTAL_DED { get; set; }
+            public long NET_PAY { get; set; }
+            public decimal? LEAVE_BAL_DAYS { get; set; }
+            public long? LOAN_BALANCE { get; set; }
+            public string? EMP_CODE { get; set; }
+            public string? FULL_NAME { get; set; }
+            public string? NATIONAL_CODE { get; set; }
+            public string? JOB_NAME { get; set; }
+            public long PERIOD_DATE { get; set; }
+            public string? WS_NAME { get; set; }
+        }
+
+        private static readonly string[] PersianMonthNames =
+        {
+            "فروردین", "اردیبهشت", "خرداد", "تیر", "مرداد", "شهریور",
+            "مهر", "آبان", "آذر", "دی", "بهمن", "اسفند"
+        };
+
+        // periodDate به فرم YYYYMM00 ⇒ «نام‌ماه YYYY»
+        private static string BuildPeriodTitle(long periodDate)
+        {
+            long year = periodDate / 10000;
+            int month = (int)((periodDate / 100) % 100);
+            string monthName = (month >= 1 && month <= 12) ? PersianMonthNames[month - 1] : "";
+            return string.IsNullOrEmpty(monthName) ? year.ToString() : $"{monthName} {year}";
+        }
+
+        // YYYYMMDD ⇒ «YYYY/MM/DD»
+        private static string FormatShamsi(long dateLong)
+        {
+            if (dateLong <= 0) return string.Empty;
+            string d = dateLong.ToString();
+            return d.Length == 8 ? $"{d[..4]}/{d.Substring(4, 2)}/{d.Substring(6, 2)}" : d;
         }
 
         [HttpPost("calculate")]

--- a/Server/Reports/PayslipDocument.cs
+++ b/Server/Reports/PayslipDocument.cs
@@ -1,0 +1,237 @@
+// File: Server/Reports/PayslipDocument.cs
+// سند QuestPDF فیش حقوقی ماژول PAY2 — راست‌به‌چپ، فونت IRANYekanFN.
+// سبک کلی (RTL، فونت، لوگو، ساختار Header/Content/Footer) از ProformaDocument پیروی می‌کند.
+using Microsoft.AspNetCore.Hosting;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+using Safir.Shared.Models.Salary.Reports;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace Safir.Server.Reports
+{
+    public class PayslipDocument : IDocument
+    {
+        private readonly PayslipReportDto _data;
+        private readonly IWebHostEnvironment _env;
+        private byte[]? _logoBytes = null;
+
+        private const string PersianFontName = "IRANYekanFN"; // در Program.cs رجیستر شده است
+        private const string LogoFileName = "2.png";
+        private const string FontsFolderName = "Fonts";
+        private static readonly CultureInfo FaCulture = new CultureInfo("fa-IR");
+
+        public PayslipDocument(PayslipReportDto data, IWebHostEnvironment env)
+        {
+            _data = data;
+            _env = env;
+
+            // بارگذاری لوگو (اختیاری — در صورت نبود، فیش بدون لوگو تولید می‌شود)
+            try
+            {
+                string logoPath = Path.Combine(_env.ContentRootPath, FontsFolderName, LogoFileName);
+                if (File.Exists(logoPath))
+                    _logoBytes = File.ReadAllBytes(logoPath);
+            }
+            catch
+            {
+                _logoBytes = null;
+            }
+        }
+
+        public DocumentMetadata GetMetadata() => DocumentMetadata.Default;
+
+        public void Compose(IDocumentContainer container)
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(1.2f, Unit.Centimetre);
+                page.PageColor(Colors.White);
+                page.DefaultTextStyle(x => x.FontSize(9).FontFamily(PersianFontName));
+                page.ContentFromRightToLeft();
+
+                page.Header().Element(ComposeHeader);
+                page.Content().Element(ComposeContent);
+                page.Footer().Element(ComposeFooter);
+            });
+        }
+
+        // ───────────────────────────── Header ─────────────────────────────
+        void ComposeHeader(IContainer container)
+        {
+            container.Column(col =>
+            {
+                col.Item().Row(row =>
+                {
+                    // راست: مشخصات کارگاه و دوره
+                    row.RelativeItem().AlignRight().Column(c =>
+                    {
+                        c.Item().Text(_data.WorkshopName).SemiBold().FontSize(12);
+                        c.Item().Text($"دوره: {_data.PeriodTitle}").FontSize(9).FontColor(Colors.Grey.Darken1);
+                    });
+
+                    // وسط: عنوان
+                    row.RelativeItem().AlignCenter().AlignMiddle().Text("فیش حقوقی").SemiBold().FontSize(16);
+
+                    // چپ: لوگو یا تاریخ چاپ
+                    if (_logoBytes != null)
+                    {
+                        row.ConstantItem(70).AlignLeft().AlignTop().Image(_logoBytes).FitArea();
+                    }
+                    else
+                    {
+                        row.RelativeItem().AlignLeft().AlignMiddle().Text(t =>
+                        {
+                            t.Span("تاریخ چاپ: ").FontSize(8).FontColor(Colors.Grey.Darken1);
+                            t.Span(_data.PrintDate ?? "").FontSize(8).FontColor(Colors.Grey.Darken1);
+                        });
+                    }
+                });
+
+                col.Item().PaddingTop(6).BorderBottom(1).BorderColor(Colors.Grey.Medium);
+
+                // نوار مشخصات پرسنل
+                col.Item().PaddingTop(6).Background(Colors.Grey.Lighten4).Padding(6).Column(info =>
+                {
+                    info.Item().Row(row =>
+                    {
+                        row.RelativeItem(2).Text(t => { t.Span("نام و نام خانوادگی: ").SemiBold(); t.Span(_data.EmployeeName); });
+                        row.RelativeItem().Text(t => { t.Span("کد پرسنلی: ").SemiBold(); t.Span(_data.EmployeeCode); });
+                        row.RelativeItem().Text(t => { t.Span("کد ملی: ").SemiBold(); t.Span(string.IsNullOrWhiteSpace(_data.NationalCode) ? "—" : _data.NationalCode); });
+                    });
+                    info.Item().PaddingTop(3).Row(row =>
+                    {
+                        row.RelativeItem(2).Text(t => { t.Span("شغل: ").SemiBold(); t.Span(string.IsNullOrWhiteSpace(_data.JobTitle) ? "—" : _data.JobTitle); });
+                        row.RelativeItem().Text(t => { t.Span("کارکرد: ").SemiBold(); t.Span($"{_data.WorkDays.ToString("0.##", FaCulture)} روز"); });
+                        row.RelativeItem().Text(t => { t.Span("مبنای بیمه: ").SemiBold(); t.Span(Money(_data.InsBase)); });
+                    });
+                });
+            });
+        }
+
+        // ───────────────────────────── Content ─────────────────────────────
+        void ComposeContent(IContainer container)
+        {
+            container.PaddingVertical(8).Row(row =>
+            {
+                // در حالت RTL، اولین آیتم سمت راست قرار می‌گیرد ⇒ راست=مزایا، چپ=کسورات
+                row.RelativeItem().Element(c =>
+                    ComposeItemsBlock(c, "مزایا و دریافتی‌ها", _data.Earnings, _data.TotalEarnings, "جمع کل مزایا", "#2E7D32"));
+
+                row.ConstantItem(12); // فاصلهٔ بین دو ستون
+
+                row.RelativeItem().Element(c =>
+                    ComposeItemsBlock(c, "کسورات", _data.Deductions, _data.TotalDeductions, "جمع کل کسورات", "#C62828"));
+            });
+        }
+
+        void ComposeItemsBlock(IContainer container, string heading, System.Collections.Generic.List<PayslipLineDto> lines,
+                               long total, string totalLabel, string accentColor)
+        {
+            container.Border(1).BorderColor(Colors.Grey.Lighten1).Column(col =>
+            {
+                // سرتیتر رنگی
+                col.Item().Background(accentColor).Padding(5).Text(heading).FontColor(Colors.White).SemiBold().FontSize(11);
+
+                // جدول اقلام
+                col.Item().Table(table =>
+                {
+                    table.ColumnsDefinition(c =>
+                    {
+                        c.RelativeColumn(3); // شرح
+                        c.RelativeColumn(2); // مبلغ
+                    });
+
+                    table.Header(h =>
+                    {
+                        static IContainer HeaderCell(IContainer c) =>
+                            c.Background(Colors.Grey.Lighten3).PaddingVertical(3).PaddingHorizontal(5);
+
+                        h.Cell().Element(HeaderCell).Text("شرح").SemiBold();
+                        h.Cell().Element(HeaderCell).AlignLeft().Text("مبلغ (ریال)").SemiBold();
+                    });
+
+                    if (lines != null && lines.Any())
+                    {
+                        foreach (var ln in lines)
+                        {
+                            static IContainer BodyCell(IContainer c) =>
+                                c.BorderBottom(1).BorderColor(Colors.Grey.Lighten2).PaddingVertical(3).PaddingHorizontal(5);
+
+                            table.Cell().Element(BodyCell).Text(ln.Title ?? "");
+                            table.Cell().Element(BodyCell).AlignLeft().Text(Money(ln.Amount));
+                        }
+                    }
+                    else
+                    {
+                        table.Cell().ColumnSpan(2).Padding(8).AlignCenter().Text("—").FontColor(Colors.Grey.Medium);
+                    }
+                });
+
+                // جمع ستون
+                col.Item().Background(Colors.Grey.Lighten4).Padding(5).Row(r =>
+                {
+                    r.RelativeItem().Text(totalLabel).SemiBold();
+                    r.RelativeItem().AlignLeft().Text(Money(total)).SemiBold();
+                });
+            });
+        }
+
+        // ───────────────────────────── Footer ─────────────────────────────
+        void ComposeFooter(IContainer container)
+        {
+            container.PaddingTop(8).Column(col =>
+            {
+                // خالص پرداختی برجسته
+                col.Item().Border(1.5f).BorderColor(Colors.Blue.Darken2).Background(Colors.Blue.Lighten5).Padding(8).Row(row =>
+                {
+                    row.RelativeItem().AlignMiddle().Text(t =>
+                    {
+                        t.Span("خالص قابل پرداخت: ").SemiBold().FontSize(12);
+                        t.Span(Money(_data.NetPay)).Bold().FontSize(15).FontColor(Colors.Blue.Darken2);
+                        t.Span(" ریال").FontSize(10);
+                    });
+                });
+
+                if (!string.IsNullOrWhiteSpace(_data.NetPayInWords))
+                {
+                    col.Item().PaddingTop(3).Text(t =>
+                    {
+                        t.Span("به حروف: ").SemiBold().FontSize(8);
+                        t.Span(_data.NetPayInWords).FontSize(8);
+                    });
+                }
+
+                // اطلاعات تکمیلی (مانده‌ها) — فقط در صورت وجود
+                bool hasLeave = _data.LeaveBalanceDays.HasValue;
+                bool hasLoan = _data.LoanBalance.HasValue && _data.LoanBalance.Value != 0;
+                if (hasLeave || hasLoan)
+                {
+                    col.Item().PaddingTop(4).Text(t =>
+                    {
+                        if (hasLeave)
+                            t.Span($"مانده مرخصی: {_data.LeaveBalanceDays!.Value.ToString("0.##", FaCulture)} روز    ")
+                             .FontSize(8).FontColor(Colors.Grey.Darken1);
+                        if (hasLoan)
+                            t.Span($"مانده وام: {Money(_data.LoanBalance!.Value)} ریال")
+                             .FontSize(8).FontColor(Colors.Grey.Darken1);
+                    });
+                }
+
+                // محل امضا
+                col.Item().PaddingTop(20).Row(row =>
+                {
+                    row.RelativeItem().AlignCenter().Text("مهر و امضاء کارفرما").FontSize(8);
+                    row.RelativeItem().AlignCenter().Text("امضاء دریافت‌کننده").FontSize(8);
+                });
+            });
+        }
+
+        // ───────────────────────────── Helpers ─────────────────────────────
+        private static string Money(long value) => value.ToString("N0", FaCulture);
+    }
+}

--- a/Shared/Models/Salary/Reports/PayslipReportDto.cs
+++ b/Shared/Models/Salary/Reports/PayslipReportDto.cs
@@ -1,0 +1,47 @@
+namespace Safir.Shared.Models.Salary.Reports
+{
+    /// <summary>
+    /// یک ردیف از اقلام فیش حقوقی (یک قلم مزایا یا یک قلم کسورات) — آمادهٔ چاپ.
+    /// </summary>
+    public class PayslipLineDto
+    {
+        public string Title { get; set; } = string.Empty;
+        public long Amount { get; set; }
+    }
+
+    /// <summary>
+    /// مدل صریح و «آمادهٔ چاپِ» فیش حقوقی یک پرسنل در یک دوره.
+    /// سند QuestPDF فقط همین مدل تمیز را می‌بیند، نه دیکشنری خامِ Details.
+    /// قرارداد داده‌ای: جمع مزایا − جمع کسورات = خالص پرداختی (NetPay).
+    /// </summary>
+    public class PayslipReportDto
+    {
+        // ── مشخصات پرسنل ──
+        public string EmployeeName { get; set; } = string.Empty;
+        public string EmployeeCode { get; set; } = string.Empty;
+        public string? NationalCode { get; set; }
+        public string? JobTitle { get; set; }
+
+        // ── دوره و کارگاه ──
+        public string PeriodTitle { get; set; } = string.Empty;   // مثل «خرداد ۱۴۰۳»
+        public long PeriodDate { get; set; }                       // YYYYMM00
+        public string WorkshopName { get; set; } = string.Empty;
+        public decimal WorkDays { get; set; }
+
+        // ── اقلام پویا ──
+        public List<PayslipLineDto> Earnings { get; set; } = new();
+        public List<PayslipLineDto> Deductions { get; set; } = new();
+
+        // ── جمع‌ها ──
+        public long TotalEarnings => Earnings.Sum(x => x.Amount);
+        public long TotalDeductions => Deductions.Sum(x => x.Amount);
+        public long NetPay { get; set; }
+        public string? NetPayInWords { get; set; }
+
+        // ── اطلاعات تکمیلی فیش ──
+        public long InsBase { get; set; }
+        public decimal? LeaveBalanceDays { get; set; }
+        public long? LoanBalance { get; set; }
+        public string? PrintDate { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive payslip (فیش حقوقی) PDF generation and preview functionality to the salary management system. Employees can now generate and view detailed payslip documents with earnings, deductions, and net pay information in Persian (RTL format).

## Key Changes

### Backend
- **PayslipDocument.cs** (new): QuestPDF-based document class that renders payslips in Persian with RTL layout, using IRANYekanFN font. Includes header (employee/workshop info), content (earnings/deductions tables), and footer (net pay, leave/loan balances, signature areas).
- **Pay2RunController.cs**: Added `GetPayslip(runId, empId)` endpoint that:
  - Retrieves employee and run data from database
  - Extracts earnings from item types 1-2 (GROSS_PAY)
  - Extracts deductions from explicit fields (TOTAL_DED)
  - Applies rounding adjustments to ensure mathematical consistency
  - Generates PDF via PayslipDocument and returns as file download
  - Includes helper methods for Persian date formatting and period title generation

### Frontend
- **PdfPreviewDialog.razor** (new): Reusable Blazor component for PDF preview/printing that:
  - Accepts a callback function to fetch PDF bytes
  - Displays loading state and error handling
  - Renders PDF in iframe using browser's native viewer (print/zoom/download controls)
  - Manages Blob URL lifecycle to prevent memory leaks
  - Supports JWT Bearer authentication (never exposes direct API URLs)

- **PayrollTab.razor**: Added "چاپ فیش" (Print Payslip) button to each employee row that opens the preview dialog

- **Pay2RunApiService.cs**: Added `GetPayslipPdfAsync(runId, empId)` method to fetch payslip PDF bytes from the API

- **interop.js**: Added JavaScript interop functions:
  - `createPdfBlobUrl()`: Converts byte array to Blob URL for iframe display
  - `revokePdfBlobUrl()`: Cleans up Blob URLs to prevent memory leaks

### Shared Models
- **PayslipReportDto.cs** (new): Clean DTO containing:
  - Employee details (name, code, national ID, job title)
  - Period and workshop information
  - Dynamic earnings/deductions line items
  - Calculated totals and net pay
  - Additional info (leave balance, loan balance, print date)

## Implementation Details
- **Data Contract**: Earnings come from item detail records (types 1-2), deductions from explicit PAY2_RUN_LINE fields. Rounding adjustments ensure: `TotalEarnings - TotalDeductions = NetPay`
- **RTL Support**: Document uses `ContentFromRightToLeft()` and Persian font throughout
- **Security**: PDF bytes fetched via authenticated API call; never exposed as direct URLs
- **UX**: Browser's native PDF viewer provides familiar print/download/zoom controls without custom implementation

https://claude.ai/code/session_01XSrBDC8BtqdijMmdD4uDnq