### PR TITLE
رفع باگ ۳۰برابرشدن حق شیفتِ درصدی (SP_PAY2_CALC_RUN)

### DIFF
--- a/Server/Info/PAY2_Procedures_v6.sql
+++ b/Server/Info/PAY2_Procedures_v6.sql
@@ -263,7 +263,8 @@ BEGIN
                         IF @SHIFT_MODE = 'FIXED'
                             SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))) AS BIGINT);
                         ELSE
-                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * 30.0 * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
+                            -- v6.2 (رفع باگ): @CURRENT_DEC_DAILY_BASE مقدارِ «ماهانه»‌ی پایه است (نه روزانه)؛ ضربِ نادرست در 30 حذف شد تا حق شیفتِ درصدی ۳۰برابر نشود
+                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
                     END
 
                     -- v6.1 (حفظ‌شده): مبنای ساعتی — آیتم‌های اضافه‌کار از ساعات کارکرد خودشان استفاده می‌کنند

--- a/Server/Info/ScriptSqly.cs
+++ b/Server/Info/ScriptSqly.cs
@@ -1486,7 +1486,8 @@ BEGIN
                         IF @SHIFT_MODE = 'FIXED'
                             SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))) AS BIGINT);
                         ELSE
-                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * 30.0 * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
+                            -- v6.2 (رفع باگ): @CURRENT_DEC_DAILY_BASE مقدارِ «ماهانه»‌ی پایه است (نه روزانه)؛ ضربِ نادرست در 30 حذف شد تا حق شیفتِ درصدی ۳۰برابر نشود
+                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
                     END
 
                     -- v6.1 (حفظ‌شده): مبنای ساعتی — آیتم‌های اضافه‌کار از ساعات کارکرد خودشان استفاده می‌کنند


### PR DESCRIPTION
## خلاصه
رفعِ باگِ تأییدشده با دیتای واقعی: در شاخهٔ **درصدیِ** حق شیفت در `SP_PAY2_CALC_RUN`، متغیر `@CURRENT_DEC_DAILY_BASE` در عدد **۳۰** ضرب می‌شد، در حالی که این متغیر — برخلاف نامش — مقدارِ **ماهانه**ی پایه را نگه می‌دارد (نه روزانه). نتیجه: حق شیفتِ درصدی **۳۰ برابر** باد می‌کرد.

این همان موردی است که در PR #95 زیر بخش «نیازمندِ تأیید با دیتای واقعی» پرچم خورده بود؛ با اجرای حقوقِ **خرداد ۱۴۰۵** دقیقاً تأیید شد.

## نمونه (پرسنل با پایهٔ ۷٬۲۱۴٬۸۵۴ و SHIFT=۲۲۵)
- قبل: `۷٬۲۱۴٬۸۵۴ × ۳۰ × ۲۲۵ ÷ ۱۰۰ = ۴۸۷٬۰۰۲٬۶۴۵`
- بعد: `۷٬۲۱۴٬۸۵۴ × ۲۲۵ ÷ ۱۰۰ = ۱۶٬۲۳۳٬۴۲۲`

## راستی‌آزمایی
- بقیهٔ اقلام از قبل درست بودند: ناخالصِ یک پرسنلِ بدونِ شیفت (ابوذر) تا **ریال** با UI یکی شد (۲۲۲٬۱۶۹٬۰۸۴).
- اصلاح در هر دو نسخهٔ **اجرایی** (`Server/Info/ScriptSqly.cs`) و **مرجع** (`Server/Info/PAY2_Procedures_v6.sql`) اعمال شد و یک کامنتِ ضدِ بازگشت اضافه شد.
- تنها نقطهٔ دارای این الگو همین فرمول بود؛ سایر کاربردهای `÷۳۰`/`×۳۰` (سقفِ بیمه، تسهیمِ روز، محاسباتِ تاریخ/سنوات) درست‌اند.

## ⚠️ نکتهٔ داده‌ای (جدا از باگ)
حتی بعد از این رفع، مقدار `SHIFT=۲۲۵` یعنی «۲۲۵٪ پایه» که برای حق شیفت غیرعادی بالاست (معمولاً ۱۰٪ تا ۲۲٫۵٪). احتمالاً منظور **۲۲٫۵** بوده. لطفاً مقدارِ آیتم را در حکم/تعریفِ آیتم بررسی کنید.

## پس از مرج (مهم)
۱) اسکریپت را دوباره روی دیتابیس اجرا کنید تا پروسیجر با `CREATE OR ALTER` بازنویسی شود.
۲) حقوقِ خرداد را **باز-محاسبه** کنید تا حق شیفت اصلاح شود.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My2shHjnJuSVEZsmqaGJHB

---
_Generated by [Claude Code](https://claude.ai/code/session_01My2shHjnJuSVEZsmqaGJHB)_