### PR TITLE
رفع باگ پایه: پرداختِ آیتم‌های روزانه به‌صورت ماهانه (نرخ روزانه × ۳۰)

### DIFF
--- a/Server/Info/PAY2_Procedures_v6.sql
+++ b/Server/Info/PAY2_Procedures_v6.sql
@@ -242,9 +242,9 @@ BEGIN
                     DECLARE @PAY_DAYS DECIMAL(18,6) = (CASE @ITEM_PBD WHEN 1 THEN @DAYS ELSE @DAYSB END) * @PRORATE_FACTOR;
                     DECLARE @BASE_DAYS_RAW DECIMAL(5,2) = (CASE @ITEM_PBD WHEN 1 THEN @DAYS ELSE @DAYSB END);
 
-                    -- 🛠 اصلاح باگ ۳۰برابری: مبلغ پایه ماهانه است و باید بر تعداد روز ماه تقسیم شود
+                    -- v6.3 (رفع باگ پایه): مبلغِ پایه نرخِ «روزانه» است (CALC_BASIS=1، مطابقِ فرمِ ثبتِ حکم که AMOUNT را در ۳۰ ضرب می‌کند)؛ ×30 آن را ماهانه می‌کند، سپس به‌نسبت کارکرد تسهیم می‌شود
                     IF @ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B')
-                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
+                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * 30.0 * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
 
                     ELSE IF @ITEM_CODE IN ('HOME','CHILDREN','GROCERY')
                     BEGIN
@@ -263,8 +263,8 @@ BEGIN
                         IF @SHIFT_MODE = 'FIXED'
                             SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))) AS BIGINT);
                         ELSE
-                            -- v6.2 (رفع باگ): @CURRENT_DEC_DAILY_BASE مقدارِ «ماهانه»‌ی پایه است (نه روزانه)؛ ضربِ نادرست در 30 حذف شد تا حق شیفتِ درصدی ۳۰برابر نشود
-                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
+                            -- v6.3 (اصلاح): @CURRENT_DEC_DAILY_BASE نرخِ «روزانه»‌ی پایه است؛ ×30 آن را ماهانه می‌کند تا حق شیفت = درصدی از حقوق پایهٔ ماهیانه شود (مطابقِ فرمِ ثبتِ حکم)
+                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * 30.0 * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
                     END
 
                     -- v6.1 (حفظ‌شده): مبنای ساعتی — آیتم‌های اضافه‌کار از ساعات کارکرد خودشان استفاده می‌کنند
@@ -286,9 +286,9 @@ BEGIN
                             ELSE CAST(@ITEM_AMOUNT * @PRORATE_FACTOR AS BIGINT)
                         END;
 
-                    -- 🛠 اصلاح باگ ۳۰برابری: آیتم‌های روزانهٔ مبلغ‌ماهانه بر تعداد روز ماه تقسیم می‌شوند
+                    -- v6.3 (رفع باگ پایه): آیتم‌های روزانه (basis=1) — نرخِ روزانه ×30 = ماهانه، سپس تسهیم به‌نسبت کارکرد
                     ELSE IF @ITEM_BASIS = 1
-                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
+                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * 30.0 * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
 
                     ELSE
                         SET @CALC_AMOUNT = ISNULL(@ITEM_AMOUNT, 0);
@@ -316,13 +316,13 @@ BEGIN
         END
         ELSE IF @OT_HOUR_BASE > 0
         BEGIN
-            -- Fallback: مبلغ پایه ماهانه از آخرین حکم؛ تقسیم بر MONTH_DAYS برای رسیدن به نرخ روزانه (اصلاح باگ ۳۰برابری)
+            -- v6.3 (رفع باگ پایه): @FALLBACK نرخِ «روزانه»‌ی پایه از آخرین حکم است؛ ×30 → ماهانه، ÷MONTH_DAYS → روزانه، ÷ساعت‌کاری → نرخ ساعتی
             DECLARE @FALLBACK_MONTHLY_BASE BIGINT = 0;
             SELECT TOP 1 @FALLBACK_MONTHLY_BASE = CAST(DL.AMOUNT AS BIGINT)
             FROM PAY2_DECREE D INNER JOIN PAY2_DECREE_LINE DL ON D.DEC_ID = DL.DEC_ID INNER JOIN PAY2_ITEM_DEF ID ON DL.ITEM_ID = ID.ITEM_ID
             WHERE D.EMP_ID = @EMP_ID AND D.IS_CONFIRMED = 1 AND ID.ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B') ORDER BY D.EFF_FROM DESC;
 
-            SET @EFFECTIVE_HOURLY = ISNULL((CAST(@FALLBACK_MONTHLY_BASE AS DECIMAL(18,2)) / CAST(@MONTH_DAYS AS DECIMAL(18,6))) / NULLIF(@OT_HOUR_BASE, 0), 0);
+            SET @EFFECTIVE_HOURLY = ISNULL((CAST(@FALLBACK_MONTHLY_BASE AS DECIMAL(18,2)) * 30.0 / CAST(@MONTH_DAYS AS DECIMAL(18,6))) / NULLIF(@OT_HOUR_BASE, 0), 0);
         END
 
         IF @OT_NORMAL_H > 0 AND NOT EXISTS (SELECT 1 FROM @ItemCalc WHERE ITEM_CODE = 'OT_NORMAL')

--- a/Server/Info/ScriptSqly.cs
+++ b/Server/Info/ScriptSqly.cs
@@ -1465,9 +1465,9 @@ BEGIN
                     DECLARE @PAY_DAYS DECIMAL(18,6) = (CASE @ITEM_PBD WHEN 1 THEN @DAYS ELSE @DAYSB END) * @PRORATE_FACTOR;
                     DECLARE @BASE_DAYS_RAW DECIMAL(5,2) = (CASE @ITEM_PBD WHEN 1 THEN @DAYS ELSE @DAYSB END);
 
-                    -- 🛠 اصلاح باگ ۳۰برابری: مبلغ پایه ماهانه است و باید بر تعداد روز ماه تقسیم شود
+                    -- v6.3 (رفع باگ پایه): مبلغِ پایه نرخِ «روزانه» است (CALC_BASIS=1، مطابقِ فرمِ ثبتِ حکم که AMOUNT را در ۳۰ ضرب می‌کند)؛ ×30 آن را ماهانه می‌کند، سپس به‌نسبت کارکرد تسهیم می‌شود
                     IF @ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B')
-                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
+                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * 30.0 * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
 
                     ELSE IF @ITEM_CODE IN ('HOME','CHILDREN','GROCERY')
                     BEGIN
@@ -1486,8 +1486,8 @@ BEGIN
                         IF @SHIFT_MODE = 'FIXED'
                             SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))) AS BIGINT);
                         ELSE
-                            -- v6.2 (رفع باگ): @CURRENT_DEC_DAILY_BASE مقدارِ «ماهانه»‌ی پایه است (نه روزانه)؛ ضربِ نادرست در 30 حذف شد تا حق شیفتِ درصدی ۳۰برابر نشود
-                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
+                            -- v6.3 (اصلاح): @CURRENT_DEC_DAILY_BASE نرخِ «روزانه»‌ی پایه است؛ ×30 آن را ماهانه می‌کند تا حق شیفت = درصدی از حقوق پایهٔ ماهیانه شود (مطابقِ فرمِ ثبتِ حکم)
+                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * 30.0 * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
                     END
 
                     -- v6.1 (حفظ‌شده): مبنای ساعتی — آیتم‌های اضافه‌کار از ساعات کارکرد خودشان استفاده می‌کنند
@@ -1509,9 +1509,9 @@ BEGIN
                             ELSE CAST(@ITEM_AMOUNT * @PRORATE_FACTOR AS BIGINT)
                         END;
 
-                    -- 🛠 اصلاح باگ ۳۰برابری: آیتم‌های روزانهٔ مبلغ‌ماهانه بر تعداد روز ماه تقسیم می‌شوند
+                    -- v6.3 (رفع باگ پایه): آیتم‌های روزانه (basis=1) — نرخِ روزانه ×30 = ماهانه، سپس تسهیم به‌نسبت کارکرد
                     ELSE IF @ITEM_BASIS = 1
-                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
+                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * 30.0 * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
 
                     ELSE
                         SET @CALC_AMOUNT = ISNULL(@ITEM_AMOUNT, 0);
@@ -1539,13 +1539,13 @@ BEGIN
         END
         ELSE IF @OT_HOUR_BASE > 0
         BEGIN
-            -- Fallback: مبلغ پایه ماهانه از آخرین حکم؛ تقسیم بر MONTH_DAYS برای رسیدن به نرخ روزانه (اصلاح باگ ۳۰برابری)
+            -- v6.3 (رفع باگ پایه): @FALLBACK نرخِ «روزانه»‌ی پایه از آخرین حکم است؛ ×30 → ماهانه، ÷MONTH_DAYS → روزانه، ÷ساعت‌کاری → نرخ ساعتی
             DECLARE @FALLBACK_MONTHLY_BASE BIGINT = 0;
             SELECT TOP 1 @FALLBACK_MONTHLY_BASE = CAST(DL.AMOUNT AS BIGINT)
             FROM PAY2_DECREE D INNER JOIN PAY2_DECREE_LINE DL ON D.DEC_ID = DL.DEC_ID INNER JOIN PAY2_ITEM_DEF ID ON DL.ITEM_ID = ID.ITEM_ID
             WHERE D.EMP_ID = @EMP_ID AND D.IS_CONFIRMED = 1 AND ID.ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B') ORDER BY D.EFF_FROM DESC;
 
-            SET @EFFECTIVE_HOURLY = ISNULL((CAST(@FALLBACK_MONTHLY_BASE AS DECIMAL(18,2)) / CAST(@MONTH_DAYS AS DECIMAL(18,6))) / NULLIF(@OT_HOUR_BASE, 0), 0);
+            SET @EFFECTIVE_HOURLY = ISNULL((CAST(@FALLBACK_MONTHLY_BASE AS DECIMAL(18,2)) * 30.0 / CAST(@MONTH_DAYS AS DECIMAL(18,6))) / NULLIF(@OT_HOUR_BASE, 0), 0);
         END
 
         IF @OT_NORMAL_H > 0 AND NOT EXISTS (SELECT 1 FROM @ItemCalc WHERE ITEM_CODE = 'OT_NORMAL')


### PR DESCRIPTION
## خلاصه
`BASE_SAL`/`BASE_SAL_B` و همهٔ آیتم‌های `CALC_BASIS=1` نرخِ **روزانه** را نگه می‌دارند — طبق نام DDL («حقوق روزانه»)، هدر اسکریپت `006`، و مهم‌تر از همه **فرمِ ثبتِ حکم** که در `DecreeLineModal.razor:318` مبلغ را در ۳۰ ضرب می‌کند تا ماهانه شود:
```csharp
return effectiveBasis == 1 ? baseLine.AMOUNT * 30 : baseLine.AMOUNT;
```
اما `SP_PAY2_CALC_RUN` آن‌ها را مثل «۱ روز» پرداخت می‌کرد (`مبلغ × روز ÷ روزهای‌ماه` ≈ خودِ مبلغ برای ماه کامل) → حقوقِ پایه ~۳۰× کم، و آبشار به بیمه/مالیات. چون کمک‌هزینه‌ها و اضافه‌کار بزرگ بودند، این کسری پنهان می‌ماند.

## اصلاح (افزودنِ ضریبِ روزانه→ماهانهٔ ×۳۰ مطابقِ فرمِ ثبتِ حکم)
- `BASE_SAL` / `BASIS=1`: `مبلغ × 30.0 × PAY_DAYS / MONTH_DAYS`
- `SHIFT` (PCT): **بازگرداندنِ** `× 30` (پایهٔ روزانه را ماهانه می‌کند؛ حذفِ آن در PR قبلی جهتش غلط بود)
- fallbackِ اضافه‌کارِ پرسنلِ غایب: `× 30` تا نرخِ روزانهٔ خام به ماهانه تبدیل شود

## راستی‌آزمایی (تا ریال — مطابقِ فرمِ ثبتِ حکم)
| بیضائی | فعلی (باگ) | بعد از فیکس | فرمِ حکم (AMOUNT×30) |
|---|---|---|---|
| پایهٔ اسمی | ۸٬۶۱۰٬۶۶۵ | ۲۵۸٬۳۱۹٬۹۵۰ | ۲۵۸٬۳۱۹٬۹۵۰ ✅ |
| پایهٔ رسمی | ۷٬۶۱۰٬۶۶۵ | ۲۲۸٬۳۱۹٬۹۵۰ | ۲۲۸٬۳۱۹٬۹۵۰ ✅ |
| ناخالص | ۲۲۲٬۱۶۹٬۰۸۴ | ۶۹۲٬۵۸۷٬۶۵۴ | — |

- **اضافه‌کار بدون تغییر** (نرخِ ساعتیِ حکم؛ `OT_NORMAL_H` ساعتِ اعشاری است نه دقیقه — `rate×6.05=8,794,316` ✓ در مقابلِ `rate×363=527M` ✗). پس فیکسِ ÷۶۰ که یک هوش مصنوعی دیگر پیشنهاد داد **اشتباه** بود.
- شیفت بعد از فیکس = `پایهٔ‌ماهانه × درصد ÷ ۱۰۰` (دقیقاً مطابقِ UI). با `۲۲٫۵٪`: ۴۸٬۷۰۰٬۲۶۴.
- هر دو فایل (`ScriptSqly.cs` اجرایی + `PAY2_Procedures_v6.sql` مرجع) یکسان نگه داشته شدند.

## ⚠️ پس از مرج
1. اسکریپت را روی دیتابیس **دوباره اجرا کنید** (پروسیجر با `CREATE OR ALTER` بازنویسی می‌شود).
2. در حکم، مقدارِ `SHIFT` را از `۲۲۵` به `۲۲٫۵` تغییر دهید.
3. خرداد را **باز-محاسبه** کنید. حقوق‌ها ~۳۰× بزرگ‌تر می‌شوند و بیمه به سقف می‌خورد — مقدارِ **سقفِ بیمه** و **معافیتِ مالیاتِ ۱۴۰۵** را در تنظیمات بررسی کنید.

## نکات باقی‌مانده (خارج از این PR)
- **`SP_PAY2_CALC_SETTLE`**: همین مشکلِ روزانه/ماهانه را در `LAST_DAILY` دارد (عیدی/سنوات/بازخریدِ مرخصی) → نیازمندِ فیکسِ جداگانه.
- شیفت در موتور از پایهٔ **اسمی** (MAX) استفاده می‌کند ولی فرم از **رسمی** (`BASE_SAL_B`)؛ و در حالتِ `REAL`، ضریبِ ثابتِ ۳۰ با ماهِ ۳۱روزه ~۳٪ اختلاف دارد.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My2shHjnJuSVEZsmqaGJHB

---
_Generated by [Claude Code](https://claude.ai/code/session_01My2shHjnJuSVEZsmqaGJHB)_