### PR TITLE
Fix Deflation Bug in Payroll Engine

### DIFF
--- a/Server/Info/PAY2_Procedures_v6.sql
+++ b/Server/Info/PAY2_Procedures_v6.sql
@@ -244,7 +244,7 @@ BEGIN
 
                     -- 🛠 اصلاح باگ ۳۰برابری: مبلغ پایه ماهانه است و باید بر تعداد روز ماه تقسیم شود
                     IF @ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B')
-                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
+                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS AS BIGINT);
 
                     ELSE IF @ITEM_CODE IN ('HOME','CHILDREN','GROCERY')
                     BEGIN
@@ -264,7 +264,7 @@ BEGIN
                             SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))) AS BIGINT);
                         ELSE
                             -- v6.2 (رفع باگ): @CURRENT_DEC_DAILY_BASE مقدارِ «ماهانه»‌ی پایه است (نه روزانه)؛ ضربِ نادرست در 30 حذف شد تا حق شیفتِ درصدی ۳۰برابر نشود
-                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * @PAY_DAYS * @ITEM_AMOUNT / 100.0), 0) AS BIGINT);
                     END
 
                     -- v6.1 (حفظ‌شده): مبنای ساعتی — آیتم‌های اضافه‌کار از ساعات کارکرد خودشان استفاده می‌کنند
@@ -322,7 +322,7 @@ BEGIN
             FROM PAY2_DECREE D INNER JOIN PAY2_DECREE_LINE DL ON D.DEC_ID = DL.DEC_ID INNER JOIN PAY2_ITEM_DEF ID ON DL.ITEM_ID = ID.ITEM_ID
             WHERE D.EMP_ID = @EMP_ID AND D.IS_CONFIRMED = 1 AND ID.ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B') ORDER BY D.EFF_FROM DESC;
 
-            SET @EFFECTIVE_HOURLY = ISNULL((CAST(@FALLBACK_MONTHLY_BASE AS DECIMAL(18,2)) / CAST(@MONTH_DAYS AS DECIMAL(18,6))) / NULLIF(@OT_HOUR_BASE, 0), 0);
+            SET @EFFECTIVE_HOURLY = ISNULL(CAST(@FALLBACK_MONTHLY_BASE AS DECIMAL(18,2)) / NULLIF(@OT_HOUR_BASE, 0), 0);
         END
 
         IF @OT_NORMAL_H > 0 AND NOT EXISTS (SELECT 1 FROM @ItemCalc WHERE ITEM_CODE = 'OT_NORMAL')

--- a/Server/Info/ScriptSqly.cs
+++ b/Server/Info/ScriptSqly.cs
@@ -1467,7 +1467,7 @@ BEGIN
 
                     -- 🛠 اصلاح باگ ۳۰برابری: مبلغ پایه ماهانه است و باید بر تعداد روز ماه تقسیم شود
                     IF @ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B')
-                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(18,6)) AS BIGINT);
+                        SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * @PAY_DAYS AS BIGINT);
 
                     ELSE IF @ITEM_CODE IN ('HOME','CHILDREN','GROCERY')
                     BEGIN
@@ -1487,7 +1487,7 @@ BEGIN
                             SET @CALC_AMOUNT = CAST(@ITEM_AMOUNT * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))) AS BIGINT);
                         ELSE
                             -- v6.2 (رفع باگ): @CURRENT_DEC_DAILY_BASE مقدارِ «ماهانه»‌ی پایه است (نه روزانه)؛ ضربِ نادرست در 30 حذف شد تا حق شیفتِ درصدی ۳۰برابر نشود
-                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * @ITEM_AMOUNT / 100.0) * (@PAY_DAYS / CAST(@MONTH_DAYS AS DECIMAL(5,2))), 0) AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND((@CURRENT_DEC_DAILY_BASE * @PAY_DAYS * @ITEM_AMOUNT / 100.0), 0) AS BIGINT);
                     END
 
                     -- v6.1 (حفظ‌شده): مبنای ساعتی — آیتم‌های اضافه‌کار از ساعات کارکرد خودشان استفاده می‌کنند
@@ -1545,7 +1545,7 @@ BEGIN
             FROM PAY2_DECREE D INNER JOIN PAY2_DECREE_LINE DL ON D.DEC_ID = DL.DEC_ID INNER JOIN PAY2_ITEM_DEF ID ON DL.ITEM_ID = ID.ITEM_ID
             WHERE D.EMP_ID = @EMP_ID AND D.IS_CONFIRMED = 1 AND ID.ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B') ORDER BY D.EFF_FROM DESC;
 
-            SET @EFFECTIVE_HOURLY = ISNULL((CAST(@FALLBACK_MONTHLY_BASE AS DECIMAL(18,2)) / CAST(@MONTH_DAYS AS DECIMAL(18,6))) / NULLIF(@OT_HOUR_BASE, 0), 0);
+            SET @EFFECTIVE_HOURLY = ISNULL(CAST(@FALLBACK_MONTHLY_BASE AS DECIMAL(18,2)) / NULLIF(@OT_HOUR_BASE, 0), 0);
         END
 
         IF @OT_NORMAL_H > 0 AND NOT EXISTS (SELECT 1 FROM @ItemCalc WHERE ITEM_CODE = 'OT_NORMAL')

--- a/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
+++ b/Server/Scripts/006_Pay2_HourlyCalcBasis.sql
@@ -260,10 +260,10 @@ BEGIN
                         ELSE
                         BEGIN
                             -- v6.1: درصدی از حقوق پایه «ماهیانه» (نرخ روزانه × 30) با تناسب روز کارکرد
-                            -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB ÷ 30  →  ضرب در @MONTH_DAYS = نرخ روزانه × DAYSB
+                            -- @BASE_SAL_B محاسبه‌شده = نرخ روزانه × DAYSB  →  درست محاسبه شده
                             -- NOTE: این منطق در Server/Info/PAY2_Procedures_v6.sql هم وجود دارد؛ تغییر باید در هر دو فایل اعمال شود
                             DECLARE @BASE_SAL_B BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL_B'), 0);
-                            SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @MONTH_DAYS * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
+                            SET @CALC_AMOUNT = CAST(ROUND(@BASE_SAL_B * @ITEM_AMOUNT / 100.0, 0) AS BIGINT);
                         END;
                     END;
                     ELSE
@@ -286,25 +286,28 @@ BEGIN
         -- گام ۶ — افزودن آیتم‌های متغیر
         -- v6.1: اگر آیتم اضافه‌کار به صورت صریح در حکم تعریف شده باشد (مثلاً با نرخ ساعتی)،
         -- محاسبه خودکار آن از روی حقوق پایه انجام نمی‌شود تا دوبار منظور نگردد
-        DECLARE @BASE_SAL_DAILY BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL' OR ITEM_CODE = 'BASE_SAL_B'), 0);
+        DECLARE @BASE_SAL_IN_MONTH BIGINT = ISNULL((SELECT TOP 1 AMOUNT FROM #ItemCalc WHERE ITEM_CODE = 'BASE_SAL' OR ITEM_CODE = 'BASE_SAL_B'), 0);
+        DECLARE @EFFECTIVE_HOURLY DECIMAL(18,2) = 0;
+        IF @DAYSB > 0 AND @OT_HOUR_BASE > 0
+            SET @EFFECTIVE_HOURLY = ISNULL((CAST(@BASE_SAL_IN_MONTH AS DECIMAL(18,2)) / @DAYSB) / NULLIF(@OT_HOUR_BASE, 0), 0);
 
         IF @OT_NORMAL_H > 0 AND NOT EXISTS (SELECT 1 FROM #ItemCalc WHERE ITEM_CODE = 'OT_NORMAL')
         BEGIN
-            DECLARE @OT_NORMAL_AMT BIGINT = ISNULL(CAST(@BASE_SAL_DAILY / (@MONTH_DAYS * @OT_HOUR_BASE) * @OT_NORMAL_H * @OT_NORMAL_MULT AS BIGINT), 0);
+            DECLARE @OT_NORMAL_AMT BIGINT = ISNULL(CAST(@EFFECTIVE_HOURLY * @OT_NORMAL_H * @OT_NORMAL_MULT AS BIGINT), 0);
             INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
             SELECT ITEM_ID, 'OT_NORMAL', 2, @OT_NORMAL_AMT, INS_SUBJECT, TAX_SUBJECT FROM PAY2_ITEM_DEF WHERE ITEM_CODE = 'OT_NORMAL';
         END;
 
         IF @OT_HOLIDAY_H > 0 AND NOT EXISTS (SELECT 1 FROM #ItemCalc WHERE ITEM_CODE = 'OT_HOLIDAY')
         BEGIN
-            DECLARE @OT_HOLIDAY_AMT BIGINT = ISNULL(CAST(@BASE_SAL_DAILY / (@MONTH_DAYS * @OT_HOUR_BASE) * @OT_HOLIDAY_H * @OT_HOLIDAY_MULT AS BIGINT), 0);
+            DECLARE @OT_HOLIDAY_AMT BIGINT = ISNULL(CAST(@EFFECTIVE_HOURLY * @OT_HOLIDAY_H * @OT_HOLIDAY_MULT AS BIGINT), 0);
             INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
             SELECT ITEM_ID, 'OT_HOLIDAY', 2, @OT_HOLIDAY_AMT, INS_SUBJECT, TAX_SUBJECT FROM PAY2_ITEM_DEF WHERE ITEM_CODE = 'OT_HOLIDAY';
         END;
 
         IF @OT_ADMIN_H > 0 AND NOT EXISTS (SELECT 1 FROM #ItemCalc WHERE ITEM_CODE = 'OT_ADMIN')
         BEGIN
-            DECLARE @OT_ADMIN_AMT BIGINT = ISNULL(CAST(@BASE_SAL_DAILY / (@MONTH_DAYS * @OT_HOUR_BASE) * @OT_ADMIN_H * @OT_NORMAL_MULT AS BIGINT), 0);
+            DECLARE @OT_ADMIN_AMT BIGINT = ISNULL(CAST(@EFFECTIVE_HOURLY * @OT_ADMIN_H * @OT_NORMAL_MULT AS BIGINT), 0);
             INSERT INTO #ItemCalc (ITEM_ID, ITEM_CODE, ITEM_TYPE, AMOUNT, INS_SUBJECT, TAX_SUBJECT)
             SELECT ITEM_ID, 'OT_ADMIN', 2, @OT_ADMIN_AMT, INS_SUBJECT, TAX_SUBJECT FROM PAY2_ITEM_DEF WHERE ITEM_CODE = 'OT_ADMIN';
         END;


### PR DESCRIPTION
Fixes a critical calculation bug where base salaries and dependent items were inadvertently divided by the number of days in a month, resulting in employees receiving roughly a single day's pay for a full month's work. By removing the extraneous division by `@MONTH_DAYS`, calculations correctly multiply the daily base stored in the system by the number of working days (`@PAY_DAYS`).

---
*PR created automatically by Jules for task [18213274183560698390](https://jules.google.com/task/18213274183560698390) started by @mojtabahakimian*