### PR TITLE
Enhance PWA refresh and auto-update mechanisms

### DIFF
--- a/Client/Shared/NavMenu.razor
+++ b/Client/Shared/NavMenu.razor
@@ -79,12 +79,16 @@
             <MudNavGroup Title="تنظیمات" Icon="@Icons.Material.Filled.Settings" Expanded="false">
                 <MudNavLink Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Person">@context.User.FindFirst(Safir.Shared.Constants.BaseknowClaimTypes.UUSER)?.Value</MudNavLink>
 
-                <MudNavLink @onclick="BeginFullCleanup" Icon="@Icons.Material.Filled.CleaningServices">
-                    تازه سازی اطلاعات
+                <MudNavLink @onclick="BeginSoftRefresh" Icon="@Icons.Material.Filled.SystemUpdateAlt">
+                    بررسی و دریافت بروزرسانی
                 </MudNavLink>
 
                 <MudNavLink @onclick="BeginServerStateReset" Icon="@Icons.Material.Filled.DeleteForever">
                     ریست ذخیره وضعیت
+                </MudNavLink>
+
+                <MudNavLink @onclick="BeginFactoryReset" Icon="@Icons.Material.Filled.DeleteForever" Style="color: var(--mud-palette-error);">
+                    ریست کامل سایت
                 </MudNavLink>
 
                 <MudNavLink Href="settings/security" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Security">
@@ -111,8 +115,12 @@
                 نسخه: @appVersion
             </MudNavLink>
 
-            <MudNavLink @onclick="BeginFullCleanup" Icon="@Icons.Material.Filled.CleaningServices">
-                تازه سازی اطلاعات
+            <MudNavLink @onclick="BeginSoftRefresh" Icon="@Icons.Material.Filled.SystemUpdateAlt">
+                بررسی و دریافت بروزرسانی
+            </MudNavLink>
+
+            <MudNavLink @onclick="BeginFactoryReset" Icon="@Icons.Material.Filled.DeleteForever" Style="color: var(--mud-palette-error);">
+                ریست کامل سایت
             </MudNavLink>
         </NotAuthorized>
     </AuthorizeView>
@@ -188,7 +196,7 @@
         var dialog = DialogService.Show<ConfirmDialog>(parameters["Title"]?.ToString()!, parameters, options);
         var result = await dialog.Result;
 
-        if (!result.Cancelled)
+        if (!result.Canceled)
         {
             try
             {
@@ -225,50 +233,66 @@
         };
         var dialog = DialogService.Show<ConfirmDialog>(parameters["Title"]?.ToString()!, parameters, options);
         var result = await dialog.Result;
-        if (!result.Cancelled)
+        if (!result.Canceled)
         {
             await AuthService.Logout();
             NavigationManager.NavigateTo("login", true);
         }
     }
-    private async Task BeginFullCleanup()
+
+    private async Task BeginSoftRefresh()
     {
         var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small };
         var parameters = new DialogParameters
         {
-            ["Title"] = "پاکسازی کامل اطلاعات مرورگر",
-            ["ContentText"] = "آیا مطمئن هستید که می‌خواهید تمامی اطلاعات ذخیره شده این سایت در مرورگر (شامل تنظیمات، کش و داده‌های آفلاین) را پاک کنید؟ این عملیات معادل باز کردن سایت برای اولین بار خواهد بود.",
-            ["ConfirmButtonText"] = "پاکسازی و شروع مجدد",
-            ["CancelButtonText"] = "منصرف شدم"
+            ["Title"] = "دریافت آخرین تغییرات",
+            ["ContentText"] = "آیا می‌خواهید برنامه را به‌روزرسانی کنید؟ (تنظیمات اتصال شما محفوظ می‌ماند)",
+            ["ConfirmButtonText"] = "بله، آپدیت کن",
+            ["CancelButtonText"] = "انصراف"
         };
         var dialog = DialogService.Show<ConfirmDialog>(parameters["Title"]?.ToString()!, parameters, options);
         var result = await dialog.Result;
 
-        if (!result.Cancelled)
+        if (!result.Canceled)
         {
             try
             {
-                // فراخوانی تابع JavaScript برای پاکسازی کامل
-                // از BeforeInvoke/AfterInvoke برای اطمینان از آماده بودن JS استفاده می کنیم.
-                await JSRuntime.InvokeVoidAsync("console.log", "Attempting to invoke appCleanup.clearAllBrowserData...");
-                var success = await JSRuntime.InvokeAsync<bool>("appCleanup.clearAllBrowserData");
-
-                if (success)
-                {
-                    Snackbar.Add("پاکسازی اطلاعات مرورگر با موفقیت انجام شد. صفحه بارگذاری مجدد می‌شود.", MudBlazor.Severity.Success);
-                    // پس از پاکسازی، کاربر را به صفحه اصلی هدایت می‌کنیم تا سایت کاملاً از نو بارگذاری شود
-                    // forceLoad: true تضمین می‌کند که مرورگر تمام منابع را دوباره دانلود کند.
-                    NavigationManager.NavigateTo("/", forceLoad: true);
-                }
-                else
-                {
-                    Snackbar.Add("خطا در پاکسازی اطلاعات مرورگر.", MudBlazor.Severity.Error);
-                }
+                await JSRuntime.InvokeAsync<bool>("appCleanup.softRefresh");
+                Snackbar.Add("کش سیستم پاک شد. صفحه در حال بارگذاری مجدد است...", MudBlazor.Severity.Success);
+                NavigationManager.NavigateTo("/", forceLoad: true);
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Error during full cleanup: {ex.Message}");
-                Snackbar.Add($"خطای غیرمنتظره در پاکسازی , صفحه را رفرش کنید و مجددا امتحان کنید", MudBlazor.Severity.Error); // Use ex.Message
+                Console.Error.WriteLine($"Error during soft refresh: {ex.Message}");
+                Snackbar.Add("خطا در به‌روزرسانی.", MudBlazor.Severity.Error);
+            }
+        }
+    }
+
+    private async Task BeginFactoryReset()
+    {
+        var options = new DialogOptions { CloseButton = false, MaxWidth = MaxWidth.Small };
+        var parameters = new DialogParameters
+        {
+            ["Title"] = "بازگشت به تنظیمات کارخانه",
+            ["ContentText"] = "هشدار! با این کار تمامی تنظیمات از جمله آدرس سرور و اطلاعات دیتابیس پاک خواهد شد و باید مجدداً لاگین کنید. آیا مطمئن هستید؟",
+            ["ConfirmButtonText"] = "بله، همه چیز پاک شود",
+            ["CancelButtonText"] = "انصراف"
+        };
+        var dialog = DialogService.Show<ConfirmDialog>(parameters["Title"]?.ToString()!, parameters, options);
+        var result = await dialog.Result;
+
+        if (!result.Canceled)
+        {
+            try
+            {
+                await JSRuntime.InvokeAsync<bool>("appCleanup.factoryReset");
+                NavigationManager.NavigateTo("/", forceLoad: true);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error during factory reset: {ex.Message}");
+                Snackbar.Add("خطا در ریست کارخانه.", MudBlazor.Severity.Error);
             }
         }
     }

--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -614,11 +614,9 @@
                         newWorker.addEventListener('statechange', () => {
                             if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
                                 if (confirm('🎉 نسخه جدیدی از نرم‌افزار سفیر در دسترس است!\n\nآیا می‌خواهید برای اعمال تغییرات، صفحه را اکنون بروزرسانی کنید؟ (تنظیمات شما پاک نمی‌شود)')) {
-                                    if ('caches' in window) {
-                                        caches.keys().then(names => {
-                                            for (let name of names) caches.delete(name);
-                                        });
-                                    }
+                                    // The manual cache deletion has been removed based on the Codex review.
+                                    // Service-worker.published.js handles cleaning up old caches in its 'activate' event
+                                    // and has already downloaded the new files in the 'install' event.
 
                                     newWorker.postMessage({ type: 'SKIP_WAITING' });
 

--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -606,9 +606,34 @@
                 });
             } else {
                 // In production, register the service worker
-                navigator.serviceWorker.register('service-worker.js')
-                    .then(reg => console.log('Service Worker: Registration successful with scope: ', reg.scope))
-                    .catch(err => console.error('Service Worker: Registration failed: ', err));
+                navigator.serviceWorker.register('service-worker.js').then(reg => {
+                    console.log('Service Worker: Registration successful with scope: ', reg.scope);
+
+                    reg.addEventListener('updatefound', () => {
+                        const newWorker = reg.installing;
+                        newWorker.addEventListener('statechange', () => {
+                            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                                if (confirm('🎉 نسخه جدیدی از نرم‌افزار سفیر در دسترس است!\n\nآیا می‌خواهید برای اعمال تغییرات، صفحه را اکنون بروزرسانی کنید؟ (تنظیمات شما پاک نمی‌شود)')) {
+                                    if ('caches' in window) {
+                                        caches.keys().then(names => {
+                                            for (let name of names) caches.delete(name);
+                                        });
+                                    }
+
+                                    newWorker.postMessage({ type: 'SKIP_WAITING' });
+
+                                    let refreshing = false;
+                                    navigator.serviceWorker.addEventListener('controllerchange', () => {
+                                        if (!refreshing) {
+                                            window.location.reload();
+                                            refreshing = true;
+                                        }
+                                    });
+                                }
+                            }
+                        });
+                    });
+                }).catch(err => console.error('Service Worker Registration failed: ', err));
             }
         }
     </script>

--- a/Client/wwwroot/js/cleanup.js
+++ b/Client/wwwroot/js/cleanup.js
@@ -1,57 +1,66 @@
 // Client\wwwroot\js\cleanup.js
 window.appCleanup = {
-    clearAllBrowserData: async function () {
-        console.log("Starting browser data cleanup...");
 
-        // Clear localStorage
+    softRefresh: async function () {
+        console.log("Starting Soft Refresh...");
+
+        const protectedKeys = ['dbConnectionSettings', 'isDarkMode', 'authToken'];
+
         try {
-            localStorage.clear();
-            console.log("localStorage cleared.");
-        } catch (e) {
-            console.error("Error clearing localStorage:", e);
-        }
+            for (let i = localStorage.length - 1; i >= 0; i--) {
+                const key = localStorage.key(i);
+                if (!protectedKeys.includes(key)) {
+                    localStorage.removeItem(key);
+                }
+            }
+        } catch (e) { console.error("Error clearing localStorage:", e); }
 
-        // Clear sessionStorage
-        try {
-            sessionStorage.clear();
-            console.log("sessionStorage cleared.");
-        } catch (e) {
-            console.error("Error clearing sessionStorage:", e);
-        }
+        try { sessionStorage.clear(); } catch (e) { }
 
-        // Clear Cache Storage (for Service Worker caches)
         if ('caches' in window) {
             try {
                 const cacheNames = await caches.keys();
                 for (const name of cacheNames) {
                     await caches.delete(name);
-                    console.log(`Cache '${name}' deleted.`);
                 }
-                console.log("All caches cleared.");
-            } catch (e) {
-                console.error("Error clearing caches:", e);
-            }
-        } else {
-            console.log("Cache API not supported or available.");
+            } catch (e) { }
         }
 
-        // Unregister all Service Workers
         if ('serviceWorker' in navigator) {
             try {
                 const registrations = await navigator.serviceWorker.getRegistrations();
                 for (const registration of registrations) {
                     await registration.unregister();
-                    console.log(`Service Worker unregistered: ${registration.scope}`);
                 }
-                console.log("All service workers unregistered.");
-            } catch (e) {
-                console.error("Error unregistering service workers:", e);
-            }
-        } else {
-            console.log("Service Worker API not supported or available.");
+            } catch (e) { }
         }
 
-        console.log("Browser data cleanup complete.");
-        return true; // Indicate success
+        return true;
+    },
+
+    factoryReset: async function () {
+        console.log("Starting Factory Reset...");
+        try { localStorage.clear(); } catch (e) { }
+        try { sessionStorage.clear(); } catch (e) { }
+
+        if ('caches' in window) {
+            try {
+                const cacheNames = await caches.keys();
+                for (const name of cacheNames) {
+                    await caches.delete(name);
+                }
+            } catch (e) { }
+        }
+
+        if ('serviceWorker' in navigator) {
+            try {
+                const registrations = await navigator.serviceWorker.getRegistrations();
+                for (const registration of registrations) {
+                    await registration.unregister();
+                }
+            } catch (e) { }
+        }
+
+        return true;
     }
 };

--- a/Client/wwwroot/service-worker.published.js
+++ b/Client/wwwroot/service-worker.published.js
@@ -46,3 +46,9 @@ async function onFetch(event) {
 
     return cachedResponse || fetch(event.request);
 }
+
+self.addEventListener('message', event => {
+    if (event.data && event.data.type === 'SKIP_WAITING') {
+        self.skipWaiting();
+    }
+});


### PR DESCRIPTION
This PR addresses the issue where the PWA cache clearing mechanism was wiping out the database connection settings and logging out the user. It separates the "refresh" functionality into two distinct actions: a soft refresh that preserves specific `localStorage` keys (`dbConnectionSettings`, `isDarkMode`, and `authToken`), and a factory reset that clears everything. It also adds a feature to detect Service Worker updates and prompt the user to apply them seamlessly without losing authentication or connection state.

---
*PR created automatically by Jules for task [18094637102272612090](https://jules.google.com/task/18094637102272612090) started by @mojtabahakimian*