### PR TITLE
Add server-generated formula-driven Excel audit export for payroll runs

### DIFF
--- a/Client/Pages/Salary/Tabs/PayrollTab.razor
+++ b/Client/Pages/Salary/Tabs/PayrollTab.razor
@@ -348,8 +348,8 @@
                             style="height:38px;"
                             @onclick="ExportExcel"
                             disabled="@(RunData.Lines.Count == 0)"
-                            title="خروجی Excel از کل فیش‌های این دوره">
-                        <i class="bi bi-file-earmark-excel"></i> خروجی Excel
+                            title="خروجی Excel فرمول‌دار و قابل ردیابی از کل فیش‌های این دوره">
+                        <i class="bi bi-file-earmark-excel"></i> خروجی Excel فرمول‌دار
                     </button>
 
                     <div style="flex-grow:1;"></div>
@@ -922,8 +922,8 @@
     }
 
     // ════════════════════════════════════════════════════════════════
-    // خروجی Excel (XLSX واقعی) از کل فیش‌های دورهٔ جاری — شامل ستون‌های
-    // پویای آیتم‌های حقوقی و ردیف جمع. مستقل از موتور خروجی Syncfusion.
+    // خروجی Excel فرمول‌دار از سرور: شیت قابل مشاهده، شیت داده خام/تنظیمات،
+    // و کنترل تطابق برای توضیح دقیق مسیر محاسبه و مقایسه با موتور C#.
     // ════════════════════════════════════════════════════════════════
     async Task ExportExcel()
     {
@@ -935,8 +935,14 @@
 
         try
         {
-            var bytes = Safir.Client.Components.Grid.SalaryGridExcelExporter.Build(RunData);
-            await JS.InvokeVoidAsync("downloadFileFromBytes", $"Payroll_{SelectedPeriodDate}.xlsx", bytes);
+            if (CurrentRun == null)
+            {
+                Snackbar.Add("اجرای حقوق برای خروجی Excel مشخص نیست.", MudBlazor.Severity.Warning);
+                return;
+            }
+
+            var bytes = await RunApi.GetExcelAuditAsync(CurrentRun.RUN_ID);
+            await JS.InvokeVoidAsync("downloadFileFromBytes", $"Payroll_Audit_{SelectedPeriodDate}_{CurrentRun.RUN_ID}.xlsx", bytes);
         }
         catch (Exception ex)
         {

--- a/Client/Services/Pay2RunApiService.cs
+++ b/Client/Services/Pay2RunApiService.cs
@@ -84,6 +84,22 @@ namespace Safir.Client.Services
             if (!res.IsSuccessStatusCode) throw new Exception(await res.Content.ReadAsStringAsync());
         }
 
+
+
+        public async Task<byte[]> GetExcelAuditAsync(int runId)
+        {
+            var res = await _http.GetAsync($"api/pay2/run/{runId}/excel-audit");
+            if (!res.IsSuccessStatusCode)
+            {
+                var err = await res.Content.ReadAsStringAsync();
+                throw new Exception(string.IsNullOrWhiteSpace(err)
+                    ? $"خطا در دریافت خروجی Excel محاسبات (کد {(int)res.StatusCode})."
+                    : err);
+            }
+
+            return await res.Content.ReadAsByteArrayAsync();
+        }
+
         // دریافت بایت‌های PDF فیش حقوقی یک پرسنل (برای نمایش در نمایشگر داخلی مرورگر)
         public async Task<byte[]> GetPayslipPdfAsync(int runId, int empId, bool isOfficial = false)
         {

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -107,7 +107,7 @@ namespace Safir.Server.Controllers
                 return NotFound("اجرای حقوق برای خروجی اکسل یافت نشد.");
 
             var columns = (await _db.DoGetDataSQLAsync<RunAuditColumn>(@"
-                SELECT DISTINCT I.ITEM_ID, I.ITEM_CODE, I.ITEM_NAME, I.SORT_ORDER, I.INS_SUBJECT, I.TAX_SUBJECT
+                SELECT DISTINCT I.ITEM_ID, I.ITEM_CODE, I.ITEM_NAME, I.ITEM_TYPE, I.SORT_ORDER, I.INS_SUBJECT, I.TAX_SUBJECT
                 FROM PAY2_RUN_DETAIL D WITH (NOLOCK)
                 INNER JOIN PAY2_ITEM_DEF I WITH (NOLOCK) ON D.ITEM_ID = I.ITEM_ID
                 WHERE D.RUN_ID = @runId
@@ -117,7 +117,7 @@ namespace Safir.Server.Controllers
                 SELECT RL.*, E.EMP_CODE, E.LAST_NAME + N' ' + E.FIRST_NAME AS FULL_NAME,
                        E.TAX_EXEMPT, E.REGION_DEPRIVATION, E.INS_TYPE,
                        ISNULL(A.OT_NORMAL_H,0) AS OT_NORMAL_H, ISNULL(A.OT_HOLIDAY_H,0) AS OT_HOLIDAY_H,
-                       ISNULL(A.OT_ADMIN_H,0) AS OT_ADMIN_H, ISNULL(A.LEAVE_DAYS,0) AS LEAVE_DAYS,
+                       ISNULL(A.OT_ADMIN_H,0) AS OT_ADMIN_H, ISNULL(A.DAYS,0) AS DAYS, ISNULL(A.DAYSB,0) AS DAYSB, ISNULL(A.FRID_COUNT,0) AS FRID_COUNT, ISNULL(A.TDAYS,0) AS TDAYS, ISNULL(A.LEAVE_DAYS,0) AS LEAVE_DAYS,
                        ISNULL(A.ABSENT_DAYS,0) AS ABSENT_DAYS, ISNULL(A.MISSION_DAYS,0) AS MISSION_DAYS,
                        ISNULL(A.PERF_AMOUNT,0) AS PERF_AMOUNT, ISNULL(A.TRANSP_AMOUNT,0) AS TRANSP_AMOUNT,
                        ISNULL(A.KASR_OTHER,0) AS KASR_OTHER
@@ -150,9 +150,10 @@ namespace Safir.Server.Controllers
             wb.CalculateMode = XLCalculateMode.Auto;
             var cfg = wb.Worksheets.Add("تنظیمات");
             var raw = wb.Worksheets.Add("داده خام");
+            var trace = wb.Worksheets.Add("ردیابی اقلام");
             var pay = wb.Worksheets.Add("فیش حقوقی");
             var ctl = wb.Worksheets.Add("کنترل تطابق");
-            cfg.RightToLeft = raw.RightToLeft = pay.RightToLeft = ctl.RightToLeft = true;
+            cfg.RightToLeft = raw.RightToLeft = trace.RightToLeft = pay.RightToLeft = ctl.RightToLeft = true;
 
             cfg.Cell(1, 1).Value = "کلید"; cfg.Cell(1, 2).Value = "مقدار"; cfg.Cell(1, 3).Value = "عنوان";
             for (int i = 0; i < configs.Count; i++)
@@ -171,14 +172,14 @@ namespace Safir.Server.Controllers
                 cfg.Cell(taxStart + 2 + i, 3).Value = taxBrackets[i].FIXED_TAX;
             }
 
-            var rawHeaders = new List<string> { "کد", "نام", "معاف از مالیات", "درصد منطقه محروم", "نوع بیمه", "روز کارکرد", "اضافه‌کاری عادی", "اضافه‌کاری تعطیل", "اضافه‌کاری اداری", "مرخصی", "غیبت", "ماموریت", "مبلغ کارانه", "ایاب ذهاب", "سایر کسورات خام" };
+            var rawHeaders = new List<string> { "کد", "نام", "معاف از مالیات", "درصد منطقه محروم", "نوع بیمه", "روز کارکرد", "روز اسمی", "روز رسمی", "جمعه", "روز غذا/تولید", "اضافه‌کاری عادی", "اضافه‌کاری تعطیل", "اضافه‌کاری اداری", "مرخصی", "غیبت", "ماموریت", "مبلغ کارانه", "ایاب ذهاب", "سایر کسورات خام" };
             rawHeaders.AddRange(columns.Select(c => c.ITEM_NAME));
             rawHeaders.AddRange(new[] { "ناخالص موتور", "مبنای بیمه موتور", "بیمه موتور", "مبنای مالیات موتور", "مالیات موتور", "وام", "مساعده", "سایر کسورات", "کل کسورات موتور", "خالص موتور" });
             for (int c = 0; c < rawHeaders.Count; c++) raw.Cell(1, c + 1).Value = rawHeaders[c];
             for (int r = 0; r < lines.Count; r++)
             {
                 var l = lines[r]; int rr = r + 2; int c = 1;
-                raw.Cell(rr, c++).Value = l.EMP_CODE; raw.Cell(rr, c++).Value = l.FULL_NAME; raw.Cell(rr, c++).Value = l.TAX_EXEMPT ? 1 : 0; raw.Cell(rr, c++).Value = l.REGION_DEPRIVATION; raw.Cell(rr, c++).Value = l.INS_TYPE; raw.Cell(rr, c++).Value = l.WORK_DAYS;
+                raw.Cell(rr, c++).Value = l.EMP_CODE; raw.Cell(rr, c++).Value = l.FULL_NAME; raw.Cell(rr, c++).Value = l.TAX_EXEMPT ? 1 : 0; raw.Cell(rr, c++).Value = l.REGION_DEPRIVATION; raw.Cell(rr, c++).Value = l.INS_TYPE; raw.Cell(rr, c++).Value = l.WORK_DAYS; raw.Cell(rr, c++).Value = l.DAYS; raw.Cell(rr, c++).Value = l.DAYSB; raw.Cell(rr, c++).Value = l.FRID_COUNT; raw.Cell(rr, c++).Value = l.TDAYS;
                 raw.Cell(rr, c++).Value = l.OT_NORMAL_H; raw.Cell(rr, c++).Value = l.OT_HOLIDAY_H; raw.Cell(rr, c++).Value = l.OT_ADMIN_H;
                 raw.Cell(rr, c++).Value = l.LEAVE_DAYS; raw.Cell(rr, c++).Value = l.ABSENT_DAYS; raw.Cell(rr, c++).Value = l.MISSION_DAYS;
                 raw.Cell(rr, c++).Value = l.PERF_AMOUNT; raw.Cell(rr, c++).Value = l.TRANSP_AMOUNT; raw.Cell(rr, c++).Value = l.KASR_OTHER;
@@ -189,21 +190,45 @@ namespace Safir.Server.Controllers
                 raw.Cell(rr, c++).Value = l.TOTAL_DED; raw.Cell(rr, c++).Value = l.NET_PAY;
             }
 
-            string[] payHeaders = { "کد", "نام", "روز کارکرد", "ناخالص فرمولی", "مبنای بیمه فرمولی", "بیمه کارگر فرمولی", "مشمول مالیات قبل معافیت", "مبنای مالیات فرمولی", "مالیات فرمولی", "کل کسورات فرمولی", "خالص پرداختی فرمولی", "شرح فرمول" };
-            for (int c = 0; c < payHeaders.Length; c++) pay.Cell(1, c + 1).Value = payHeaders[c];
-            int itemStartCol = 16;
-            int grossRawCol = 15 + columns.Count + 1;
+            int itemStartCol = 20;
+            int grossRawCol = 19 + columns.Count + 1;
             int loanRawCol = grossRawCol + 5;
             int advRawCol = grossRawCol + 6;
             int otherDedRawCol = grossRawCol + 7;
+
+            string[] traceHeaders = { "کد", "نام", "کد آیتم", "نام آیتم", "نوع آیتم", "مبلغ موتور", "مبلغ فرمولی", "فرمول قابل مشاهده", "شرح مسیر" };
+            for (int c = 0; c < traceHeaders.Length; c++) trace.Cell(1, c + 1).Value = traceHeaders[c];
+            int traceRow = 2;
+            for (int r = 0; r < lines.Count; r++)
+            {
+                int rawRow = r + 2;
+                for (int i = 0; i < columns.Count; i++)
+                {
+                    var col = columns[i];
+                    int itemRawCol = itemStartCol + i;
+                    string rawRef = $"'داده خام'!{ColLetter(itemRawCol)}{rawRow}";
+                    trace.Cell(traceRow, 1).FormulaA1 = $"'داده خام'!A{rawRow}";
+                    trace.Cell(traceRow, 2).FormulaA1 = $"'داده خام'!B{rawRow}";
+                    trace.Cell(traceRow, 3).Value = col.ITEM_CODE;
+                    trace.Cell(traceRow, 4).Value = col.ITEM_NAME;
+                    trace.Cell(traceRow, 5).Value = col.ITEM_TYPE;
+                    trace.Cell(traceRow, 6).FormulaA1 = rawRef;
+                    trace.Cell(traceRow, 7).FormulaA1 = BuildItemTraceFormula(col.ITEM_CODE, rawRow, rawRef, itemStartCol, columns);
+                    trace.Cell(traceRow, 8).FormulaA1 = $"FORMULATEXT(G{traceRow})";
+                    trace.Cell(traceRow, 9).Value = BuildItemTraceDescription(col.ITEM_CODE);
+                    traceRow++;
+                }
+            }
+
+            string[] payHeaders = { "کد", "نام", "روز کارکرد", "ناخالص فرمولی", "مبنای بیمه فرمولی", "بیمه کارگر فرمولی", "مشمول مالیات قبل معافیت", "مبنای مالیات فرمولی", "مالیات فرمولی", "کل کسورات فرمولی", "خالص پرداختی فرمولی", "شرح فرمول" };
+            for (int c = 0; c < payHeaders.Length; c++) pay.Cell(1, c + 1).Value = payHeaders[c];
             for (int r = 0; r < lines.Count; r++)
             {
                 int rr = r + 2;
                 pay.Cell(rr, 1).FormulaA1 = $"'داده خام'!A{rr}";
                 pay.Cell(rr, 2).FormulaA1 = $"'داده خام'!B{rr}";
                 pay.Cell(rr, 3).FormulaA1 = $"'داده خام'!F{rr}";
-                string itemRange = $"'داده خام'!{ColLetter(itemStartCol)}{rr}:{ColLetter(itemStartCol + columns.Count - 1)}{rr}";
-                pay.Cell(rr, 4).FormulaA1 = columns.Count > 0 ? $"ROUND(SUM({itemRange}),0)" : "0";
+                pay.Cell(rr, 4).FormulaA1 = columns.Count > 0 ? $"ROUND(SUMIFS('ردیابی اقلام'!G:G,'ردیابی اقلام'!A:A,A{rr},'ردیابی اقلام'!E:E,1)+SUMIFS('ردیابی اقلام'!G:G,'ردیابی اقلام'!A:A,A{rr},'ردیابی اقلام'!E:E,2)-SUMIFS('ردیابی اقلام'!G:G,'ردیابی اقلام'!A:A,A{rr},'ردیابی اقلام'!C:C,\"BASE_SAL_B\"),0)" : "0";
                 pay.Cell(rr, 5).FormulaA1 = BuildInsuranceBaseFormula(columns, rr, itemStartCol);
                 pay.Cell(rr, 6).FormulaA1 = $"IF('داده خام'!E{rr}=3,0,ROUND(E{rr}*IFERROR(VLOOKUP(\"INS_WORKER_RATE\",'تنظیمات'!A:B,2,FALSE)/100,0.07),0))";
                 pay.Cell(rr, 7).FormulaA1 = BuildSubjectSumFormula(columns, rr, itemStartCol, x => x.TAX_SUBJECT);
@@ -395,10 +420,52 @@ namespace Safir.Server.Controllers
 
 
 
+
+        private static string BuildItemTraceFormula(string itemCode, int rawRow, string rawRef, int itemStartCol, List<RunAuditColumn> columns)
+        {
+            string cfg = "'تنظیمات'!A:B";
+            string baseSum = BuildItemCodeSumExpression(rawRow, itemStartCol, columns, "BASE_SAL", "BASE_SAL_B");
+            string hourly = $"IF('داده خام'!H{rawRow}>0,(({baseSum})/'داده خام'!H{rawRow})/IFERROR(VLOOKUP(\"OT_HOUR_BASE\",{cfg},2,FALSE),7.33),0)";
+            return itemCode switch
+            {
+                "OT_NORMAL" => $"ROUND({hourly}*'داده خام'!K{rawRow}*IFERROR(VLOOKUP(\"OT_NORMAL_MULT\",{cfg},2,FALSE),1.4),0)",
+                "OT_HOLIDAY" => $"ROUND({hourly}*'داده خام'!L{rawRow}*IFERROR(VLOOKUP(\"OT_HOLIDAY_MULT\",{cfg},2,FALSE),1.4),0)",
+                "OT_ADMIN" => $"ROUND({hourly}*'داده خام'!M{rawRow}*IFERROR(VLOOKUP(\"OT_NORMAL_MULT\",{cfg},2,FALSE),1.4),0)",
+                "PERF_BONUS" => $"'داده خام'!Q{rawRow}",
+                "TRANSP" => $"'داده خام'!R{rawRow}",
+                "INS_DED" => $"'فیش حقوقی'!F{rawRow}",
+                "TAX_DED" => $"'فیش حقوقی'!I{rawRow}",
+                "LOAN_DED" => rawRef,
+                "ADVANCE_DED" => rawRef,
+                _ => rawRef
+            };
+        }
+
+        private static string BuildItemTraceDescription(string itemCode)
+        {
+            return itemCode switch
+            {
+                "OT_NORMAL" => "نرخ ساعتی موثر = جمع پایه / روز رسمی / OT_HOUR_BASE؛ سپس × ساعت اضافه‌کار عادی × OT_NORMAL_MULT",
+                "OT_HOLIDAY" => "نرخ ساعتی موثر = جمع پایه / روز رسمی / OT_HOUR_BASE؛ سپس × ساعت تعطیل‌کاری × OT_HOLIDAY_MULT",
+                "OT_ADMIN" => "نرخ ساعتی موثر = جمع پایه / روز رسمی / OT_HOUR_BASE؛ سپس × ساعت اضافه‌کار اداری × OT_NORMAL_MULT",
+                "PERF_BONUS" => "مبلغ متغیر کارانه از کارکرد ماه",
+                "TRANSP" => "مبلغ متغیر ایاب‌وذهاب از کارکرد ماه",
+                "INS_DED" => "برابر فرمول بیمه کارگر در شیت فیش حقوقی",
+                "TAX_DED" => "برابر فرمول مالیات پلکانی در شیت فیش حقوقی",
+                _ => "مبلغ محاسبه‌شده موتور؛ برای تکمیل ۱۰۰٪ باید Trace حکم/Override/Proration در موتور ثبت شود"
+            };
+        }
+
+        private static string BuildItemCodeSumExpression(int rawRow, int itemStartCol, List<RunAuditColumn> columns, params string[] itemCodes)
+        {
+            var refs = columns.Select((c, i) => new { c, i }).Where(x => itemCodes.Contains(x.c.ITEM_CODE)).Select(x => $"'داده خام'!{ColLetter(itemStartCol + x.i)}{rawRow}").ToList();
+            return refs.Count == 0 ? "0" : string.Join("+", refs);
+        }
+
         private static string BuildInsuranceBaseFormula(List<RunAuditColumn> columns, int row, int firstRawItemCol)
         {
             string subjectSum = BuildSubjectSumExpression(columns, row, firstRawItemCol, x => x.INS_SUBJECT);
-            string ceiling = $"IF(IFERROR(VLOOKUP(\"INS_CEILING_APPLY\",'تنظیمات'!A:B,2,FALSE),1)=1,IFERROR(VLOOKUP(\"INS_CEILING_MONTHLY\",'تنظیمات'!A:B,2,FALSE),{subjectSum})*'داده خام'!F{row}/30,{subjectSum})";
+            string ceiling = $"IF(IFERROR(VLOOKUP(\"INS_CEILING_APPLY\",'تنظیمات'!A:B,2,FALSE),1)=1,IFERROR(VLOOKUP(\"INS_CEILING_MONTHLY\",'تنظیمات'!A:B,2,FALSE),{subjectSum})*IF('داده خام'!H{row}>0,'داده خام'!H{row},'داده خام'!G{row})/30,{subjectSum})";
             return $"IF('داده خام'!E{row}=3,0,ROUND(MIN({subjectSum},{ceiling}),0))";
         }
 
@@ -457,10 +524,11 @@ namespace Safir.Server.Controllers
         }
 
         private class RunAuditHead { public int RUN_ID { get; set; } public int PER_ID { get; set; } public int WS_ID { get; set; } public long PERIOD_DATE { get; set; } public string WS_NAME { get; set; } = ""; }
-        private class RunAuditColumn { public int ITEM_ID { get; set; } public string ITEM_CODE { get; set; } = ""; public string ITEM_NAME { get; set; } = ""; public int SORT_ORDER { get; set; } public bool INS_SUBJECT { get; set; } public bool TAX_SUBJECT { get; set; } }
+        private class RunAuditColumn { public int ITEM_ID { get; set; } public string ITEM_CODE { get; set; } = ""; public string ITEM_NAME { get; set; } = ""; public byte ITEM_TYPE { get; set; } public int SORT_ORDER { get; set; } public bool INS_SUBJECT { get; set; } public bool TAX_SUBJECT { get; set; } }
         private class RunAuditLine : Pay2RunLineDto
         {
             public decimal OT_NORMAL_H { get; set; } public decimal OT_HOLIDAY_H { get; set; } public decimal OT_ADMIN_H { get; set; }
+            public decimal DAYS { get; set; } public decimal DAYSB { get; set; } public byte FRID_COUNT { get; set; } public decimal TDAYS { get; set; }
             public decimal LEAVE_DAYS { get; set; } public decimal ABSENT_DAYS { get; set; } public decimal MISSION_DAYS { get; set; }
             public bool TAX_EXEMPT { get; set; } public decimal REGION_DEPRIVATION { get; set; } public byte INS_TYPE { get; set; }
             public long PERF_AMOUNT { get; set; } public long TRANSP_AMOUNT { get; set; } public long KASR_OTHER { get; set; }

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -146,14 +146,68 @@ namespace Safir.Server.Controllers
                 WHERE TAX_YEAR = @taxYear
                 ORDER BY SORT_ORDER", new { taxYear })).ToList();
 
+            var configMap = configs.ToDictionary(x => x.CFG_KEY, x => x.CFG_VALUE, StringComparer.OrdinalIgnoreCase);
+            int monthDays = ResolveMonthDays(head.PERIOD_DATE, configMap);
+            int periodStart = (int)(head.PERIOD_DATE + 1);
+            int periodEnd = (int)(head.PERIOD_DATE + monthDays);
+
+            var decreeTraceRows = (await _db.DoGetDataSQLAsync<RunAuditDecreeRow>(@"
+                SELECT E.EMP_ID, E.EMP_CODE, E.LAST_NAME + N' ' + E.FIRST_NAME AS FULL_NAME,
+                       D.DEC_ID, D.EFF_FROM, ISNULL(D.EFF_TO, 99991231) AS EFF_TO,
+                       I.ITEM_CODE, I.ITEM_NAME, I.ITEM_TYPE, ISNULL(DL.AMOUNT,0) AS DEC_AMOUNT,
+                       ISNULL(OV.BASIS_OV, ISNULL(DL.BASIS_OV, I.CALC_BASIS)) AS EFFECTIVE_BASIS,
+                       ISNULL(OV.INS_OV, ISNULL(DL.INS_OV, I.INS_SUBJECT)) AS EFFECTIVE_INS,
+                       ISNULL(OV.TAX_OV, ISNULL(DL.TAX_OV, I.TAX_SUBJECT)) AS EFFECTIVE_TAX,
+                       I.PAY_BASE_DAYS, I.INS_BASE_DAYS,
+                       ISNULL(A.DAYS,0) AS DAYS, ISNULL(A.DAYSB,0) AS DAYSB, ISNULL(A.FRID_COUNT,0) AS FRID_COUNT,
+                       ISNULL(A.TDAYS,0) AS TDAYS, ISNULL(A.LEAVE_DAYS,0) AS LEAVE_DAYS,
+                       ISNULL(A.OT_NORMAL_H,0) AS OT_NORMAL_H, ISNULL(A.OT_HOLIDAY_H,0) AS OT_HOLIDAY_H, ISNULL(A.OT_ADMIN_H,0) AS OT_ADMIN_H,
+                       COALESCE(NULLIF(DL.SHIFT_MODE_OV, N''), NULLIF(D.SHIFT_MODE, N''), NULLIF(W.SHIFT_MODE, N''), @shiftMode, N'PCT') AS EFFECTIVE_SHIFT_MODE,
+                       ISNULL(BaseLine.CURRENT_DEC_DAILY_BASE,0) AS CURRENT_DEC_DAILY_BASE,
+                       CASE WHEN OV.ITEM_ID IS NULL THEN 0 ELSE 1 END AS HAS_OVERRIDE
+                FROM PAY2_RUN_LINE RL WITH (NOLOCK)
+                INNER JOIN PAY2_EMPLOYEE E WITH (NOLOCK) ON E.EMP_ID = RL.EMP_ID
+                INNER JOIN PAY2_ATTENDANCE A WITH (NOLOCK) ON A.PER_ID = @perId AND A.EMP_ID = RL.EMP_ID
+                INNER JOIN PAY2_DECREE D WITH (NOLOCK) ON D.EMP_ID = RL.EMP_ID AND D.IS_CONFIRMED = 1
+                    AND D.EFF_FROM <= @periodEnd AND (D.EFF_TO IS NULL OR D.EFF_TO >= @periodStart)
+                INNER JOIN PAY2_WORKSHOP W WITH (NOLOCK) ON W.WS_ID = @wsId
+                INNER JOIN PAY2_DECREE_LINE DL WITH (NOLOCK) ON DL.DEC_ID = D.DEC_ID
+                INNER JOIN PAY2_ITEM_DEF I WITH (NOLOCK) ON I.ITEM_ID = DL.ITEM_ID AND I.IS_ACTIVE = 1
+                OUTER APPLY (
+                    SELECT TOP 1 O.ITEM_ID, O.INS_OV, O.TAX_OV, O.BASIS_OV
+                    FROM PAY2_OVERRIDE O WITH (NOLOCK)
+                    WHERE O.EMP_ID = E.EMP_ID AND O.ITEM_ID = DL.ITEM_ID
+                      AND O.VALID_FROM <= @periodDate AND (O.VALID_TO IS NULL OR O.VALID_TO >= @periodDate)
+                    ORDER BY O.VALID_FROM DESC
+                ) OV
+                OUTER APPLY (
+                    SELECT TOP 1 DL2.AMOUNT AS CURRENT_DEC_DAILY_BASE
+                    FROM PAY2_DECREE_LINE DL2 WITH (NOLOCK)
+                    INNER JOIN PAY2_ITEM_DEF ID2 WITH (NOLOCK) ON ID2.ITEM_ID = DL2.ITEM_ID
+                    WHERE DL2.DEC_ID = D.DEC_ID AND ID2.ITEM_CODE IN ('BASE_SAL', 'BASE_SAL_B')
+                    ORDER BY CASE WHEN ID2.ITEM_CODE = 'BASE_SAL_B' THEN 1 ELSE 2 END
+                ) BaseLine
+                WHERE RL.RUN_ID = @runId AND I.ITEM_CODE NOT IN ('INS_DED','TAX_DED','LOAN_DED','ADVANCE_DED')
+                ORDER BY E.EMP_CODE, D.EFF_FROM, I.SORT_ORDER", new
+            {
+                runId,
+                perId = head.PER_ID,
+                wsId = head.WS_ID,
+                periodStart,
+                periodEnd,
+                periodDate = head.PERIOD_DATE,
+                shiftMode = GetConfigText(configMap, "SHIFT_MODE", "PCT")
+            })).ToList();
+
             using var wb = new XLWorkbook();
             wb.CalculateMode = XLCalculateMode.Auto;
             var cfg = wb.Worksheets.Add("تنظیمات");
             var raw = wb.Worksheets.Add("داده خام");
+            var decreeTrace = wb.Worksheets.Add("ردیابی حکم");
             var trace = wb.Worksheets.Add("ردیابی اقلام");
             var pay = wb.Worksheets.Add("فیش حقوقی");
             var ctl = wb.Worksheets.Add("کنترل تطابق");
-            cfg.RightToLeft = raw.RightToLeft = trace.RightToLeft = pay.RightToLeft = ctl.RightToLeft = true;
+            cfg.RightToLeft = raw.RightToLeft = decreeTrace.RightToLeft = trace.RightToLeft = pay.RightToLeft = ctl.RightToLeft = true;
 
             cfg.Cell(1, 1).Value = "کلید"; cfg.Cell(1, 2).Value = "مقدار"; cfg.Cell(1, 3).Value = "عنوان";
             for (int i = 0; i < configs.Count; i++)
@@ -195,6 +249,31 @@ namespace Safir.Server.Controllers
             int loanRawCol = grossRawCol + 5;
             int advRawCol = grossRawCol + 6;
             int otherDedRawCol = grossRawCol + 7;
+
+            string[] decreeHeaders = { "کد", "نام", "شناسه حکم", "از", "تا", "کد آیتم", "نام آیتم", "مبلغ حکم", "مبنا", "روز پرداخت", "روز بیمه", "روز فعال", "روز ماه", "ضریب حکم", "PAY_DAYS", "INS_DAYS", "BASE_DAYS", "INS_DAYS_RAW", "شیفت", "پایه شیفت", "Override", "مبلغ فرمولی", "فرمول", "شرح" };
+            for (int c = 0; c < decreeHeaders.Length; c++) decreeTrace.Cell(1, c + 1).Value = decreeHeaders[c];
+            for (int i = 0; i < decreeTraceRows.Count; i++)
+            {
+                var d = decreeTraceRows[i];
+                int rr = i + 2;
+                int activeStart = Math.Max(d.EFF_FROM, periodStart);
+                int activeEnd = Math.Min(d.EFF_TO, periodEnd);
+                int activeDays = activeStart <= activeEnd ? (activeEnd % 100) - (activeStart % 100) + 1 : 0;
+
+                decreeTrace.Cell(rr, 1).Value = d.EMP_CODE; decreeTrace.Cell(rr, 2).Value = d.FULL_NAME; decreeTrace.Cell(rr, 3).Value = d.DEC_ID;
+                decreeTrace.Cell(rr, 4).Value = d.EFF_FROM; decreeTrace.Cell(rr, 5).Value = d.EFF_TO; decreeTrace.Cell(rr, 6).Value = d.ITEM_CODE;
+                decreeTrace.Cell(rr, 7).Value = d.ITEM_NAME; decreeTrace.Cell(rr, 8).Value = d.DEC_AMOUNT; decreeTrace.Cell(rr, 9).Value = d.EFFECTIVE_BASIS;
+                decreeTrace.Cell(rr, 10).Value = d.PAY_BASE_DAYS; decreeTrace.Cell(rr, 11).Value = d.INS_BASE_DAYS; decreeTrace.Cell(rr, 12).Value = activeDays;
+                decreeTrace.Cell(rr, 13).Value = monthDays; decreeTrace.Cell(rr, 14).FormulaA1 = $"L{rr}/M{rr}";
+                decreeTrace.Cell(rr, 15).FormulaA1 = $"IF(J{rr}=1,{X(d.DAYS)},{X(d.DAYSB)})*N{rr}";
+                decreeTrace.Cell(rr, 16).FormulaA1 = $"IF(K{rr}=1,{X(d.DAYS)},{X(d.DAYSB)})*N{rr}";
+                decreeTrace.Cell(rr, 17).FormulaA1 = $"IF(J{rr}=1,{X(d.DAYS)},{X(d.DAYSB)})";
+                decreeTrace.Cell(rr, 18).FormulaA1 = $"IF(K{rr}=1,{X(d.DAYS)},{X(d.DAYSB)})";
+                decreeTrace.Cell(rr, 19).Value = d.EFFECTIVE_SHIFT_MODE; decreeTrace.Cell(rr, 20).Value = d.CURRENT_DEC_DAILY_BASE; decreeTrace.Cell(rr, 21).Value = d.HAS_OVERRIDE;
+                decreeTrace.Cell(rr, 22).FormulaA1 = BuildDecreeTraceFormula(rr, d);
+                decreeTrace.Cell(rr, 23).FormulaA1 = $"FORMULATEXT(V{rr})";
+                decreeTrace.Cell(rr, 24).Value = BuildDecreeTraceDescription(d);
+            }
 
             string[] traceHeaders = { "کد", "نام", "کد آیتم", "نام آیتم", "نوع آیتم", "مبلغ موتور", "مبلغ فرمولی", "فرمول قابل مشاهده", "شرح مسیر" };
             for (int c = 0; c < traceHeaders.Length; c++) trace.Cell(1, c + 1).Value = traceHeaders[c];
@@ -421,6 +500,58 @@ namespace Safir.Server.Controllers
 
 
 
+
+        private static int ResolveMonthDays(long periodDate, Dictionary<string, string> configMap)
+        {
+            string mode = GetConfigText(configMap, "MONTH_DAYS_MODE", "30");
+            if (mode == "30") return 30;
+
+            int year = (int)(periodDate / 10000);
+            int month = (int)((periodDate / 100) % 100);
+            bool isLeap = ((25 * year + 11) % 33) < 8;
+            if (month <= 6) return 31;
+            if (month <= 11) return 30;
+            return isLeap ? 30 : 29;
+        }
+
+        private static string GetConfigText(Dictionary<string, string> configMap, string key, string fallback)
+            => configMap.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value) ? value : fallback;
+
+        private static string BuildDecreeTraceFormula(int row, RunAuditDecreeRow d)
+        {
+            string monthlyProrate = "IFERROR(VLOOKUP(\"MONTHLY_ITEM_PRORATE\",'تنظیمات'!A:B,2,FALSE),0)";
+            string naharDays = $"({X(d.DAYSB)}-{d.FRID_COUNT}-{X(d.LEAVE_DAYS)}+{X(d.TDAYS)})";
+            return d.ITEM_CODE switch
+            {
+                "BASE_SAL" or "BASE_SAL_B" => $"ROUND(H{row}*O{row},0)",
+                "HOME" or "CHILDREN" or "GROCERY" => $"ROUND(IF(Q{row}>=28,H{row},H{row}*(Q{row}/30))*N{row},0)",
+                "NAHAR" => $"ROUND(IF({naharDays}*N{row}>0,H{row}*({naharDays}*N{row}),H{row}*O{row}),0)",
+                "SHIFT" => $"IF(S{row}=\"FIXED\",ROUND(H{row}*(O{row}/M{row}),0),ROUND(T{row}*O{row}*H{row}/100,0))",
+                "OT_NORMAL" when d.EFFECTIVE_BASIS == 3 => $"ROUND(H{row}*{X(d.OT_NORMAL_H)},0)",
+                "OT_HOLIDAY" when d.EFFECTIVE_BASIS == 3 => $"ROUND(H{row}*{X(d.OT_HOLIDAY_H)},0)",
+                "OT_ADMIN" when d.EFFECTIVE_BASIS == 3 => $"ROUND(H{row}*{X(d.OT_ADMIN_H)},0)",
+                _ when d.EFFECTIVE_BASIS == 3 => $"ROUND(H{row}*O{row}*IFERROR(VLOOKUP(\"OT_HOUR_BASE\",'تنظیمات'!A:B,2,FALSE),7.33),0)",
+                _ when d.EFFECTIVE_BASIS == 2 => $"IF({monthlyProrate}=1,ROUND(H{row}*(O{row}/M{row}),0),ROUND(H{row}*N{row},0))",
+                _ when d.EFFECTIVE_BASIS == 1 => $"ROUND(H{row}*O{row},0)",
+                _ => $"ROUND(H{row},0)"
+            };
+        }
+
+        private static string X(decimal value) => value.ToString(CultureInfo.InvariantCulture);
+
+        private static string BuildDecreeTraceDescription(RunAuditDecreeRow d)
+        {
+            string ov = d.HAS_OVERRIDE == 1 ? " با اعمال Override" : " بدون Override";
+            return d.ITEM_CODE switch
+            {
+                "BASE_SAL" or "BASE_SAL_B" => "مبلغ روزانه حکم × PAY_DAYS" + ov,
+                "HOME" or "CHILDREN" or "GROCERY" => "مزایای ماهانه: اگر روز مبنا >= ۲۸ مبلغ کامل، وگرنه نسبت ۳۰ روز × ضریب حکم" + ov,
+                "NAHAR" => "حق نهار: مبلغ × (DAYSB - جمعه - مرخصی + TDAYS) × ضریب حکم" + ov,
+                "SHIFT" => "حق شیفت: حالت FIXED یا درصدی طبق اولویت خط حکم/حکم/کارگاه/تنظیمات" + ov,
+                _ => $"محاسبه بر اساس CALC_BASIS={d.EFFECTIVE_BASIS} و PAY_BASE_DAYS/INS_BASE_DAYS" + ov
+            };
+        }
+
         private static string BuildItemTraceFormula(string itemCode, int rawRow, string rawRef, int itemStartCol, List<RunAuditColumn> columns)
         {
             string cfg = "'تنظیمات'!A:B";
@@ -525,6 +656,18 @@ namespace Safir.Server.Controllers
 
         private class RunAuditHead { public int RUN_ID { get; set; } public int PER_ID { get; set; } public int WS_ID { get; set; } public long PERIOD_DATE { get; set; } public string WS_NAME { get; set; } = ""; }
         private class RunAuditColumn { public int ITEM_ID { get; set; } public string ITEM_CODE { get; set; } = ""; public string ITEM_NAME { get; set; } = ""; public byte ITEM_TYPE { get; set; } public int SORT_ORDER { get; set; } public bool INS_SUBJECT { get; set; } public bool TAX_SUBJECT { get; set; } }
+        private class RunAuditDecreeRow
+        {
+            public int EMP_ID { get; set; } public string EMP_CODE { get; set; } = ""; public string FULL_NAME { get; set; } = "";
+            public int DEC_ID { get; set; } public int EFF_FROM { get; set; } public int EFF_TO { get; set; }
+            public string ITEM_CODE { get; set; } = ""; public string ITEM_NAME { get; set; } = ""; public byte ITEM_TYPE { get; set; }
+            public decimal DEC_AMOUNT { get; set; } public byte EFFECTIVE_BASIS { get; set; } public bool EFFECTIVE_INS { get; set; } public bool EFFECTIVE_TAX { get; set; }
+            public byte PAY_BASE_DAYS { get; set; } public byte INS_BASE_DAYS { get; set; }
+            public decimal DAYS { get; set; } public decimal DAYSB { get; set; } public byte FRID_COUNT { get; set; } public decimal TDAYS { get; set; } public decimal LEAVE_DAYS { get; set; }
+            public decimal OT_NORMAL_H { get; set; } public decimal OT_HOLIDAY_H { get; set; } public decimal OT_ADMIN_H { get; set; }
+            public string EFFECTIVE_SHIFT_MODE { get; set; } = "PCT"; public decimal CURRENT_DEC_DAILY_BASE { get; set; } public int HAS_OVERRIDE { get; set; }
+        }
+
         private class RunAuditLine : Pay2RunLineDto
         {
             public decimal OT_NORMAL_H { get; set; } public decimal OT_HOLIDAY_H { get; set; } public decimal OT_ADMIN_H { get; set; }

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -275,7 +275,7 @@ namespace Safir.Server.Controllers
                 decreeTrace.Cell(rr, 24).Value = BuildDecreeTraceDescription(d);
             }
 
-            string[] traceHeaders = { "کد", "نام", "کد آیتم", "نام آیتم", "نوع آیتم", "مبلغ موتور", "مبلغ فرمولی", "فرمول قابل مشاهده", "شرح مسیر" };
+            string[] traceHeaders = { "کد", "نام", "کد آیتم", "نام آیتم", "نوع آیتم", "مبلغ موتور", "مبلغ فرمولی", "فرمول قابل مشاهده", "شرح مسیر", "مشمول بیمه", "مشمول مالیات" };
             for (int c = 0; c < traceHeaders.Length; c++) trace.Cell(1, c + 1).Value = traceHeaders[c];
             int traceRow = 2;
             for (int r = 0; r < lines.Count; r++)
@@ -295,6 +295,8 @@ namespace Safir.Server.Controllers
                     trace.Cell(traceRow, 7).FormulaA1 = BuildItemTraceFormula(col.ITEM_CODE, rawRow, rawRef, itemStartCol, columns);
                     trace.Cell(traceRow, 8).FormulaA1 = $"FORMULATEXT(G{traceRow})";
                     trace.Cell(traceRow, 9).Value = BuildItemTraceDescription(col.ITEM_CODE);
+                    trace.Cell(traceRow, 10).Value = col.INS_SUBJECT ? 1 : 0;
+                    trace.Cell(traceRow, 11).Value = col.TAX_SUBJECT ? 1 : 0;
                     traceRow++;
                 }
             }
@@ -564,12 +566,19 @@ namespace Safir.Server.Controllers
                 "OT_ADMIN" => $"ROUND({hourly}*'داده خام'!M{rawRow}*IFERROR(VLOOKUP(\"OT_NORMAL_MULT\",{cfg},2,FALSE),1.4),0)",
                 "PERF_BONUS" => $"'داده خام'!Q{rawRow}",
                 "TRANSP" => $"'داده خام'!R{rawRow}",
-                "INS_DED" => $"'فیش حقوقی'!F{rawRow}",
-                "TAX_DED" => $"'فیش حقوقی'!I{rawRow}",
+                "INS_DED" => rawRef,
+                "TAX_DED" => rawRef,
                 "LOAN_DED" => rawRef,
                 "ADVANCE_DED" => rawRef,
-                _ => rawRef
+                _ => BuildDecreeBackedItemFormula(itemCode, rawRow, rawRef)
             };
+        }
+
+        private static string BuildDecreeBackedItemFormula(string itemCode, int rawRow, string rawRef)
+        {
+            string code = itemCode.Replace("\"", "\"\"");
+            string sum = $"SUMIFS('ردیابی حکم'!V:V,'ردیابی حکم'!A:A,'داده خام'!A{rawRow},'ردیابی حکم'!F:F,\"{code}\")";
+            return $"IF({sum}<>0,{sum},{rawRef})";
         }
 
         private static string BuildItemTraceDescription(string itemCode)
@@ -583,7 +592,7 @@ namespace Safir.Server.Controllers
                 "TRANSP" => "مبلغ متغیر ایاب‌وذهاب از کارکرد ماه",
                 "INS_DED" => "برابر فرمول بیمه کارگر در شیت فیش حقوقی",
                 "TAX_DED" => "برابر فرمول مالیات پلکانی در شیت فیش حقوقی",
-                _ => "مبلغ محاسبه‌شده موتور؛ برای تکمیل ۱۰۰٪ باید Trace حکم/Override/Proration در موتور ثبت شود"
+                _ => "اگر آیتم حکمی باشد از شیت ردیابی حکم با SUMIFS جمع می‌شود؛ اگر آیتم متغیر/خارج از حکم باشد به مبلغ موتور متصل می‌شود"
             };
         }
 
@@ -595,7 +604,7 @@ namespace Safir.Server.Controllers
 
         private static string BuildInsuranceBaseFormula(List<RunAuditColumn> columns, int row, int firstRawItemCol)
         {
-            string subjectSum = BuildSubjectSumExpression(columns, row, firstRawItemCol, x => x.INS_SUBJECT);
+            string subjectSum = $"SUMIFS('ردیابی اقلام'!G:G,'ردیابی اقلام'!A:A,'داده خام'!A{row},'ردیابی اقلام'!J:J,1)";
             string ceiling = $"IF(IFERROR(VLOOKUP(\"INS_CEILING_APPLY\",'تنظیمات'!A:B,2,FALSE),1)=1,IFERROR(VLOOKUP(\"INS_CEILING_MONTHLY\",'تنظیمات'!A:B,2,FALSE),{subjectSum})*IF('داده خام'!H{row}>0,'داده خام'!H{row},'داده خام'!G{row})/30,{subjectSum})";
             return $"IF('داده خام'!E{row}=3,0,ROUND(MIN({subjectSum},{ceiling}),0))";
         }
@@ -608,7 +617,7 @@ namespace Safir.Server.Controllers
 
         private static string BuildSubjectSumFormula(List<RunAuditColumn> columns, int row, int firstRawItemCol, Func<RunAuditColumn, bool> subject)
         {
-            return $"ROUND({BuildSubjectSumExpression(columns, row, firstRawItemCol, subject)},0)";
+            return $"ROUND(SUMIFS('ردیابی اقلام'!G:G,'ردیابی اقلام'!A:A,'داده خام'!A{row},'ردیابی اقلام'!K:K,1),0)";
         }
 
         private static string GenerateMonthlyTaxFormula(string monthlyBaseRef, List<Pay2TaxBracketDto> brackets)

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -205,9 +205,10 @@ namespace Safir.Server.Controllers
             var raw = wb.Worksheets.Add("داده خام");
             var decreeTrace = wb.Worksheets.Add("ردیابی حکم");
             var trace = wb.Worksheets.Add("ردیابی اقلام");
+            var deductionTrace = wb.Worksheets.Add("ردیابی کسورات");
             var pay = wb.Worksheets.Add("فیش حقوقی");
             var ctl = wb.Worksheets.Add("کنترل تطابق");
-            cfg.RightToLeft = raw.RightToLeft = decreeTrace.RightToLeft = trace.RightToLeft = pay.RightToLeft = ctl.RightToLeft = true;
+            cfg.RightToLeft = raw.RightToLeft = decreeTrace.RightToLeft = trace.RightToLeft = deductionTrace.RightToLeft = pay.RightToLeft = ctl.RightToLeft = true;
 
             cfg.Cell(1, 1).Value = "کلید"; cfg.Cell(1, 2).Value = "مقدار"; cfg.Cell(1, 3).Value = "عنوان";
             for (int i = 0; i < configs.Count; i++)
@@ -301,6 +302,19 @@ namespace Safir.Server.Controllers
                 }
             }
 
+            string[] deductionHeaders = { "کد", "نام", "کد کسر", "عنوان کسر", "مبلغ موتور", "مبلغ فرمولی", "فرمول", "شرح" };
+            for (int c = 0; c < deductionHeaders.Length; c++) deductionTrace.Cell(1, c + 1).Value = deductionHeaders[c];
+            int deductionRow = 2;
+            for (int r = 0; r < lines.Count; r++)
+            {
+                int rawRow = r + 2;
+                AddDeductionTraceRow(deductionTrace, deductionRow++, rawRow, "INS_DED", "بیمه کارگر", $"'فیش حقوقی'!F{rawRow}", "مبنای بیمه × INS_WORKER_RATE");
+                AddDeductionTraceRow(deductionTrace, deductionRow++, rawRow, "TAX_DED", "مالیات", $"'فیش حقوقی'!I{rawRow}", "مالیات پلکانی سالانه/۱۲ پس از معافیت‌ها");
+                AddDeductionTraceRow(deductionTrace, deductionRow++, rawRow, "LOAN_DED", "قسط وام", $"'داده خام'!{ColLetter(loanRawCol)}{rawRow}", "جمع اقساط PAY2_LOAN_SCHED ثبت‌شده برای این Run/دوره");
+                AddDeductionTraceRow(deductionTrace, deductionRow++, rawRow, "ADVANCE_DED", "مساعده", $"'داده خام'!{ColLetter(advRawCol)}{rawRow}", "خروجی مساعده هوشمند موتور در لحظه Run");
+                AddDeductionTraceRow(deductionTrace, deductionRow++, rawRow, "OTHER_DED", "سایر کسورات", $"'داده خام'!{ColLetter(otherDedRawCol)}{rawRow}", "کسورات دستی/سایر از کارکرد ماه");
+            }
+
             string[] payHeaders = { "کد", "نام", "روز کارکرد", "ناخالص فرمولی", "مبنای بیمه فرمولی", "بیمه کارگر فرمولی", "مشمول مالیات قبل معافیت", "مبنای مالیات فرمولی", "مالیات فرمولی", "کل کسورات فرمولی", "خالص پرداختی فرمولی", "شرح فرمول" };
             for (int c = 0; c < payHeaders.Length; c++) pay.Cell(1, c + 1).Value = payHeaders[c];
             for (int r = 0; r < lines.Count; r++)
@@ -315,7 +329,7 @@ namespace Safir.Server.Controllers
                 pay.Cell(rr, 7).FormulaA1 = BuildSubjectSumFormula(columns, rr, itemStartCol, x => x.TAX_SUBJECT);
                 pay.Cell(rr, 8).FormulaA1 = $"IF('داده خام'!C{rr}=1,0,ROUND(MAX(0,(G{rr}-IF(IFERROR(VLOOKUP(\"TAX_DEDUCT_INS\",'تنظیمات'!A:B,2,FALSE),1)=1,F{rr},0)-IFERROR(VLOOKUP(\"TAX_EXEMPT_MONTHLY\",'تنظیمات'!A:B,2,FALSE),0))*IF(IFERROR(VLOOKUP(\"TAX_DEPRIVATION_APPLY\",'تنظیمات'!A:B,2,FALSE),1)=1,1-'داده خام'!D{rr}/100,1)),0))";
                 pay.Cell(rr, 9).FormulaA1 = GenerateMonthlyTaxFormula($"H{rr}", taxBrackets);
-                pay.Cell(rr, 10).FormulaA1 = $"ROUND(F{rr}+I{rr}+'داده خام'!{ColLetter(loanRawCol)}{rr}+'داده خام'!{ColLetter(advRawCol)}{rr}+'داده خام'!{ColLetter(otherDedRawCol)}{rr},0)";
+                pay.Cell(rr, 10).FormulaA1 = $"ROUND(SUMIFS('ردیابی کسورات'!F:F,'ردیابی کسورات'!A:A,A{rr}),0)";
                 pay.Cell(rr, 11).FormulaA1 = $"ROUND((D{rr}-J{rr})/IFERROR(VLOOKUP(\"ROUND_MODE\",'تنظیمات'!A:B,2,FALSE),1),0)*IFERROR(VLOOKUP(\"ROUND_MODE\",'تنظیمات'!A:B,2,FALSE),1)";
                 pay.Cell(rr, 12).Value = "بیمه: MIN اقلام مشمول با سقف INS_CEILING؛ مالیات: اقلام مشمول - بیمه در صورت TAX_DEDUCT_INS - معافیت - منطقه؛ سپس مالیات سالانه/۱۲";
             }
@@ -566,12 +580,30 @@ namespace Safir.Server.Controllers
                 "OT_ADMIN" => $"ROUND({hourly}*'داده خام'!M{rawRow}*IFERROR(VLOOKUP(\"OT_NORMAL_MULT\",{cfg},2,FALSE),1.4),0)",
                 "PERF_BONUS" => $"'داده خام'!Q{rawRow}",
                 "TRANSP" => $"'داده خام'!R{rawRow}",
-                "INS_DED" => rawRef,
-                "TAX_DED" => rawRef,
-                "LOAN_DED" => rawRef,
-                "ADVANCE_DED" => rawRef,
+                "INS_DED" => BuildDeductionBackedFormula("INS_DED", rawRow, rawRef),
+                "TAX_DED" => BuildDeductionBackedFormula("TAX_DED", rawRow, rawRef),
+                "LOAN_DED" => BuildDeductionBackedFormula("LOAN_DED", rawRow, rawRef),
+                "ADVANCE_DED" => BuildDeductionBackedFormula("ADVANCE_DED", rawRow, rawRef),
                 _ => BuildDecreeBackedItemFormula(itemCode, rawRow, rawRef)
             };
+        }
+
+        private static void AddDeductionTraceRow(IXLWorksheet ws, int row, int rawRow, string code, string title, string formula, string description)
+        {
+            ws.Cell(row, 1).FormulaA1 = $"'داده خام'!A{rawRow}";
+            ws.Cell(row, 2).FormulaA1 = $"'داده خام'!B{rawRow}";
+            ws.Cell(row, 3).Value = code;
+            ws.Cell(row, 4).Value = title;
+            ws.Cell(row, 5).FormulaA1 = formula;
+            ws.Cell(row, 6).FormulaA1 = formula;
+            ws.Cell(row, 7).FormulaA1 = $"FORMULATEXT(F{row})";
+            ws.Cell(row, 8).Value = description;
+        }
+
+        private static string BuildDeductionBackedFormula(string itemCode, int rawRow, string rawRef)
+        {
+            string sum = $"SUMIFS('ردیابی کسورات'!F:F,'ردیابی کسورات'!A:A,'داده خام'!A{rawRow},'ردیابی کسورات'!C:C,\"{itemCode}\")";
+            return $"IF({sum}<>0,{sum},{rawRef})";
         }
 
         private static string BuildDecreeBackedItemFormula(string itemCode, int rawRow, string rawRef)

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -1,4 +1,5 @@
-﻿using Dapper;
+﻿using ClosedXML.Excel;
+using Dapper;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using QuestPDF.Fluent;
@@ -7,6 +8,7 @@ using Safir.Shared.Interfaces;
 using Safir.Shared.Models.Salary;
 using Safir.Shared.Models.Salary.Reports;
 using Safir.Shared.Utility;
+using System.Globalization;
 using System.Security.Claims;
 
 namespace Safir.Server.Controllers
@@ -87,6 +89,150 @@ namespace Safir.Server.Controllers
             }
 
             return Ok(result);
+        }
+
+
+
+        [HttpGet("{runId:int}/excel-audit")]
+        public async Task<IActionResult> GetExcelAudit(int runId)
+        {
+            var head = await _db.DoGetDataSQLAsyncSingle<RunAuditHead>(@"
+                SELECT R.RUN_ID, R.PER_ID, P.WS_ID, P.PERIOD_DATE, W.WS_NAME
+                FROM PAY2_RUN R WITH (NOLOCK)
+                INNER JOIN PAY2_PERIOD P WITH (NOLOCK) ON R.PER_ID = P.PER_ID
+                INNER JOIN PAY2_WORKSHOP W WITH (NOLOCK) ON P.WS_ID = W.WS_ID
+                WHERE R.RUN_ID = @runId", new { runId });
+
+            if (head == null)
+                return NotFound("اجرای حقوق برای خروجی اکسل یافت نشد.");
+
+            var columns = (await _db.DoGetDataSQLAsync<RunAuditColumn>(@"
+                SELECT DISTINCT I.ITEM_ID, I.ITEM_CODE, I.ITEM_NAME, I.SORT_ORDER, I.INS_SUBJECT, I.TAX_SUBJECT
+                FROM PAY2_RUN_DETAIL D WITH (NOLOCK)
+                INNER JOIN PAY2_ITEM_DEF I WITH (NOLOCK) ON D.ITEM_ID = I.ITEM_ID
+                WHERE D.RUN_ID = @runId
+                ORDER BY I.SORT_ORDER", new { runId })).ToList();
+
+            var lines = (await _db.DoGetDataSQLAsync<RunAuditLine>(@"
+                SELECT RL.*, E.EMP_CODE, E.LAST_NAME + N' ' + E.FIRST_NAME AS FULL_NAME,
+                       E.TAX_EXEMPT, E.REGION_DEPRIVATION, E.INS_TYPE,
+                       ISNULL(A.OT_NORMAL_H,0) AS OT_NORMAL_H, ISNULL(A.OT_HOLIDAY_H,0) AS OT_HOLIDAY_H,
+                       ISNULL(A.OT_ADMIN_H,0) AS OT_ADMIN_H, ISNULL(A.LEAVE_DAYS,0) AS LEAVE_DAYS,
+                       ISNULL(A.ABSENT_DAYS,0) AS ABSENT_DAYS, ISNULL(A.MISSION_DAYS,0) AS MISSION_DAYS,
+                       ISNULL(A.PERF_AMOUNT,0) AS PERF_AMOUNT, ISNULL(A.TRANSP_AMOUNT,0) AS TRANSP_AMOUNT,
+                       ISNULL(A.KASR_OTHER,0) AS KASR_OTHER
+                FROM PAY2_RUN_LINE RL WITH (NOLOCK)
+                INNER JOIN PAY2_EMPLOYEE E WITH (NOLOCK) ON RL.EMP_ID = E.EMP_ID
+                LEFT JOIN PAY2_ATTENDANCE A WITH (NOLOCK) ON A.PER_ID = @perId AND A.EMP_ID = RL.EMP_ID
+                WHERE RL.RUN_ID = @runId
+                ORDER BY E.LAST_NAME, E.FIRST_NAME", new { runId, perId = head.PER_ID })).ToList();
+
+            var details = await _db.DoGetDataSQLAsync<RunDetailFlat>(@"
+                SELECT D.EMP_ID, I.ITEM_CODE, D.AMOUNT
+                FROM PAY2_RUN_DETAIL D WITH (NOLOCK)
+                INNER JOIN PAY2_ITEM_DEF I WITH (NOLOCK) ON D.ITEM_ID = I.ITEM_ID
+                WHERE D.RUN_ID = @runId", new { runId });
+            var detailMap = details.GroupBy(x => x.EMP_ID).ToDictionary(g => g.Key, g => g.ToDictionary(x => x.ITEM_CODE, x => x.AMOUNT));
+
+            var configs = (await _db.DoGetDataSQLAsync<Pay2ConfigDto>(@"
+                SELECT CFG_KEY, CFG_VALUE, CFG_OPTIONS, CFG_DEFAULT, CFG_SECTION, LABEL_FA, DESC_FA, OPT_LABELS, DATA_TYPE, ACCESS_LEVEL
+                FROM PAY2_CONFIG WITH (NOLOCK)
+                ORDER BY CFG_SECTION, CFG_KEY")).ToList();
+
+            short taxYear = (short)(head.PERIOD_DATE / 10000);
+            var taxBrackets = (await _db.DoGetDataSQLAsync<Pay2TaxBracketDto>(@"
+                SELECT BRK_ID, TAX_YEAR, UPPER_LIMIT, RATE_PCT, FIXED_TAX, SORT_ORDER
+                FROM PAY2_TAX_BRACKET WITH (NOLOCK)
+                WHERE TAX_YEAR = @taxYear
+                ORDER BY SORT_ORDER", new { taxYear })).ToList();
+
+            using var wb = new XLWorkbook();
+            wb.CalculateMode = XLCalculateMode.Auto;
+            var cfg = wb.Worksheets.Add("تنظیمات");
+            var raw = wb.Worksheets.Add("داده خام");
+            var pay = wb.Worksheets.Add("فیش حقوقی");
+            var ctl = wb.Worksheets.Add("کنترل تطابق");
+            cfg.RightToLeft = raw.RightToLeft = pay.RightToLeft = ctl.RightToLeft = true;
+
+            cfg.Cell(1, 1).Value = "کلید"; cfg.Cell(1, 2).Value = "مقدار"; cfg.Cell(1, 3).Value = "عنوان";
+            for (int i = 0; i < configs.Count; i++)
+            {
+                cfg.Cell(i + 2, 1).Value = configs[i].CFG_KEY;
+                cfg.Cell(i + 2, 2).Value = configs[i].CFG_VALUE;
+                cfg.Cell(i + 2, 3).Value = configs[i].LABEL_FA;
+            }
+            int taxStart = configs.Count + 4;
+            cfg.Cell(taxStart, 1).Value = "پله‌های مالیاتی";
+            cfg.Cell(taxStart + 1, 1).Value = "سقف"; cfg.Cell(taxStart + 1, 2).Value = "نرخ"; cfg.Cell(taxStart + 1, 3).Value = "مالیات ثابت";
+            for (int i = 0; i < taxBrackets.Count; i++)
+            {
+                cfg.Cell(taxStart + 2 + i, 1).Value = taxBrackets[i].UPPER_LIMIT;
+                cfg.Cell(taxStart + 2 + i, 2).Value = taxBrackets[i].RATE_PCT / 100m;
+                cfg.Cell(taxStart + 2 + i, 3).Value = taxBrackets[i].FIXED_TAX;
+            }
+
+            var rawHeaders = new List<string> { "کد", "نام", "معاف از مالیات", "درصد منطقه محروم", "نوع بیمه", "روز کارکرد", "اضافه‌کاری عادی", "اضافه‌کاری تعطیل", "اضافه‌کاری اداری", "مرخصی", "غیبت", "ماموریت", "مبلغ کارانه", "ایاب ذهاب", "سایر کسورات خام" };
+            rawHeaders.AddRange(columns.Select(c => c.ITEM_NAME));
+            rawHeaders.AddRange(new[] { "ناخالص موتور", "مبنای بیمه موتور", "بیمه موتور", "مبنای مالیات موتور", "مالیات موتور", "وام", "مساعده", "سایر کسورات", "کل کسورات موتور", "خالص موتور" });
+            for (int c = 0; c < rawHeaders.Count; c++) raw.Cell(1, c + 1).Value = rawHeaders[c];
+            for (int r = 0; r < lines.Count; r++)
+            {
+                var l = lines[r]; int rr = r + 2; int c = 1;
+                raw.Cell(rr, c++).Value = l.EMP_CODE; raw.Cell(rr, c++).Value = l.FULL_NAME; raw.Cell(rr, c++).Value = l.TAX_EXEMPT ? 1 : 0; raw.Cell(rr, c++).Value = l.REGION_DEPRIVATION; raw.Cell(rr, c++).Value = l.INS_TYPE; raw.Cell(rr, c++).Value = l.WORK_DAYS;
+                raw.Cell(rr, c++).Value = l.OT_NORMAL_H; raw.Cell(rr, c++).Value = l.OT_HOLIDAY_H; raw.Cell(rr, c++).Value = l.OT_ADMIN_H;
+                raw.Cell(rr, c++).Value = l.LEAVE_DAYS; raw.Cell(rr, c++).Value = l.ABSENT_DAYS; raw.Cell(rr, c++).Value = l.MISSION_DAYS;
+                raw.Cell(rr, c++).Value = l.PERF_AMOUNT; raw.Cell(rr, c++).Value = l.TRANSP_AMOUNT; raw.Cell(rr, c++).Value = l.KASR_OTHER;
+                detailMap.TryGetValue(l.EMP_ID, out var empDetails);
+                foreach (var col in columns) raw.Cell(rr, c++).Value = empDetails != null && empDetails.TryGetValue(col.ITEM_CODE, out var amount) ? amount : 0;
+                raw.Cell(rr, c++).Value = l.GROSS_PAY; raw.Cell(rr, c++).Value = l.INS_BASE; raw.Cell(rr, c++).Value = l.INS_WORKER; raw.Cell(rr, c++).Value = l.TAX_BASE;
+                raw.Cell(rr, c++).Value = l.TAX_AMOUNT; raw.Cell(rr, c++).Value = l.LOAN_DED; raw.Cell(rr, c++).Value = l.ADVANCE_DED; raw.Cell(rr, c++).Value = l.OTHER_DED;
+                raw.Cell(rr, c++).Value = l.TOTAL_DED; raw.Cell(rr, c++).Value = l.NET_PAY;
+            }
+
+            string[] payHeaders = { "کد", "نام", "روز کارکرد", "ناخالص فرمولی", "مبنای بیمه فرمولی", "بیمه کارگر فرمولی", "مشمول مالیات قبل معافیت", "مبنای مالیات فرمولی", "مالیات فرمولی", "کل کسورات فرمولی", "خالص پرداختی فرمولی", "شرح فرمول" };
+            for (int c = 0; c < payHeaders.Length; c++) pay.Cell(1, c + 1).Value = payHeaders[c];
+            int itemStartCol = 16;
+            int grossRawCol = 15 + columns.Count + 1;
+            int loanRawCol = grossRawCol + 5;
+            int advRawCol = grossRawCol + 6;
+            int otherDedRawCol = grossRawCol + 7;
+            for (int r = 0; r < lines.Count; r++)
+            {
+                int rr = r + 2;
+                pay.Cell(rr, 1).FormulaA1 = $"'داده خام'!A{rr}";
+                pay.Cell(rr, 2).FormulaA1 = $"'داده خام'!B{rr}";
+                pay.Cell(rr, 3).FormulaA1 = $"'داده خام'!F{rr}";
+                string itemRange = $"'داده خام'!{ColLetter(itemStartCol)}{rr}:{ColLetter(itemStartCol + columns.Count - 1)}{rr}";
+                pay.Cell(rr, 4).FormulaA1 = columns.Count > 0 ? $"ROUND(SUM({itemRange}),0)" : "0";
+                pay.Cell(rr, 5).FormulaA1 = BuildInsuranceBaseFormula(columns, rr, itemStartCol);
+                pay.Cell(rr, 6).FormulaA1 = $"IF('داده خام'!E{rr}=3,0,ROUND(E{rr}*IFERROR(VLOOKUP(\"INS_WORKER_RATE\",'تنظیمات'!A:B,2,FALSE)/100,0.07),0))";
+                pay.Cell(rr, 7).FormulaA1 = BuildSubjectSumFormula(columns, rr, itemStartCol, x => x.TAX_SUBJECT);
+                pay.Cell(rr, 8).FormulaA1 = $"IF('داده خام'!C{rr}=1,0,ROUND(MAX(0,(G{rr}-IF(IFERROR(VLOOKUP(\"TAX_DEDUCT_INS\",'تنظیمات'!A:B,2,FALSE),1)=1,F{rr},0)-IFERROR(VLOOKUP(\"TAX_EXEMPT_MONTHLY\",'تنظیمات'!A:B,2,FALSE),0))*IF(IFERROR(VLOOKUP(\"TAX_DEPRIVATION_APPLY\",'تنظیمات'!A:B,2,FALSE),1)=1,1-'داده خام'!D{rr}/100,1)),0))";
+                pay.Cell(rr, 9).FormulaA1 = GenerateMonthlyTaxFormula($"H{rr}", taxBrackets);
+                pay.Cell(rr, 10).FormulaA1 = $"ROUND(F{rr}+I{rr}+'داده خام'!{ColLetter(loanRawCol)}{rr}+'داده خام'!{ColLetter(advRawCol)}{rr}+'داده خام'!{ColLetter(otherDedRawCol)}{rr},0)";
+                pay.Cell(rr, 11).FormulaA1 = $"ROUND((D{rr}-J{rr})/IFERROR(VLOOKUP(\"ROUND_MODE\",'تنظیمات'!A:B,2,FALSE),1),0)*IFERROR(VLOOKUP(\"ROUND_MODE\",'تنظیمات'!A:B,2,FALSE),1)";
+                pay.Cell(rr, 12).Value = "بیمه: MIN اقلام مشمول با سقف INS_CEILING؛ مالیات: اقلام مشمول - بیمه در صورت TAX_DEDUCT_INS - معافیت - منطقه؛ سپس مالیات سالانه/۱۲";
+            }
+
+            string[] ctlHeaders = { "کد", "نام", "اختلاف ناخالص", "اختلاف بیمه", "اختلاف مالیات", "اختلاف خالص", "وضعیت" };
+            for (int c = 0; c < ctlHeaders.Length; c++) ctl.Cell(1, c + 1).Value = ctlHeaders[c];
+            for (int r = 0; r < lines.Count; r++)
+            {
+                int rr = r + 2;
+                ctl.Cell(rr, 1).FormulaA1 = $"'فیش حقوقی'!A{rr}";
+                ctl.Cell(rr, 2).FormulaA1 = $"'فیش حقوقی'!B{rr}";
+                ctl.Cell(rr, 3).FormulaA1 = $"'فیش حقوقی'!D{rr}-'داده خام'!{ColLetter(grossRawCol)}{rr}";
+                ctl.Cell(rr, 4).FormulaA1 = $"'فیش حقوقی'!F{rr}-'داده خام'!{ColLetter(grossRawCol + 2)}{rr}";
+                ctl.Cell(rr, 5).FormulaA1 = $"'فیش حقوقی'!I{rr}-'داده خام'!{ColLetter(grossRawCol + 4)}{rr}";
+                ctl.Cell(rr, 6).FormulaA1 = $"'فیش حقوقی'!K{rr}-'داده خام'!{ColLetter(grossRawCol + 9)}{rr}";
+                ctl.Cell(rr, 7).FormulaA1 = $"IF(MAX(ABS(C{rr}),ABS(D{rr}),ABS(E{rr}),ABS(F{rr}))<=10,\"OK\",\"CHECK\")";
+            }
+
+            foreach (var ws in wb.Worksheets) { ws.Row(1).Style.Font.Bold = true; ws.Columns().AdjustToContents(); ws.SheetView.FreezeRows(1); }
+            cfg.Hide(); raw.Hide();
+            using var ms = new MemoryStream();
+            wb.SaveAs(ms);
+            return File(ms.ToArray(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"Payroll_Audit_{head.PERIOD_DATE}_{runId}.xlsx");
         }
 
         // کلاس کمکی برای Dapper
@@ -244,6 +390,80 @@ namespace Safir.Server.Controllers
             public string? JOB_NAME { get; set; }
             public long PERIOD_DATE { get; set; }
             public string? WS_NAME { get; set; }
+        }
+
+
+
+
+        private static string BuildInsuranceBaseFormula(List<RunAuditColumn> columns, int row, int firstRawItemCol)
+        {
+            string subjectSum = BuildSubjectSumExpression(columns, row, firstRawItemCol, x => x.INS_SUBJECT);
+            string ceiling = $"IF(IFERROR(VLOOKUP(\"INS_CEILING_APPLY\",'تنظیمات'!A:B,2,FALSE),1)=1,IFERROR(VLOOKUP(\"INS_CEILING_MONTHLY\",'تنظیمات'!A:B,2,FALSE),{subjectSum})*'داده خام'!F{row}/30,{subjectSum})";
+            return $"IF('داده خام'!E{row}=3,0,ROUND(MIN({subjectSum},{ceiling}),0))";
+        }
+
+        private static string BuildSubjectSumExpression(List<RunAuditColumn> columns, int row, int firstRawItemCol, Func<RunAuditColumn, bool> subject)
+        {
+            var refs = columns.Select((c, i) => new { c, i }).Where(x => subject(x.c)).Select(x => $"'داده خام'!{ColLetter(firstRawItemCol + x.i)}{row}").ToList();
+            return refs.Count == 0 ? "0" : $"SUM({string.Join(",", refs)})";
+        }
+
+        private static string BuildSubjectSumFormula(List<RunAuditColumn> columns, int row, int firstRawItemCol, Func<RunAuditColumn, bool> subject)
+        {
+            return $"ROUND({BuildSubjectSumExpression(columns, row, firstRawItemCol, subject)},0)";
+        }
+
+        private static string GenerateMonthlyTaxFormula(string monthlyBaseRef, List<Pay2TaxBracketDto> brackets)
+        {
+            var ordered = brackets.OrderBy(x => x.SORT_ORDER).ToList();
+            if (ordered.Count == 0) return "0";
+
+            string annualBaseRef = $"({monthlyBaseRef}*12)";
+            var highest = ordered[^1];
+            string expr = TaxBracketFormulaPart(annualBaseRef, brackets, highest);
+            for (int i = ordered.Count - 2; i >= 0; i--)
+            {
+                var b = ordered[i];
+                string upper = b.UPPER_LIMIT.ToString(CultureInfo.InvariantCulture);
+                expr = $"IF({annualBaseRef}<={upper},{TaxBracketFormulaPart(annualBaseRef, brackets, b)},{expr})";
+            }
+
+            return $"ROUND(({expr})/12,0)";
+        }
+
+        private static string TaxBracketFormulaPart(string baseRef, List<Pay2TaxBracketDto> brackets, Pay2TaxBracketDto bracket)
+        {
+            string rate = (bracket.RATE_PCT / 100m).ToString(CultureInfo.InvariantCulture);
+            string fixedTax = bracket.FIXED_TAX.ToString(CultureInfo.InvariantCulture);
+            return $"{fixedTax}+MAX(0,{baseRef}-{PreviousLimit(brackets, bracket)})*{rate}";
+        }
+
+        private static string PreviousLimit(List<Pay2TaxBracketDto> brackets, Pay2TaxBracketDto current)
+        {
+            var prev = brackets.Where(x => x.SORT_ORDER < current.SORT_ORDER).OrderByDescending(x => x.SORT_ORDER).FirstOrDefault();
+            return (prev?.UPPER_LIMIT ?? 0).ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static string ColLetter(int index)
+        {
+            var sb = new System.Text.StringBuilder();
+            while (index > 0)
+            {
+                int rem = (index - 1) % 26;
+                sb.Insert(0, (char)('A' + rem));
+                index = (index - 1) / 26;
+            }
+            return sb.ToString();
+        }
+
+        private class RunAuditHead { public int RUN_ID { get; set; } public int PER_ID { get; set; } public int WS_ID { get; set; } public long PERIOD_DATE { get; set; } public string WS_NAME { get; set; } = ""; }
+        private class RunAuditColumn { public int ITEM_ID { get; set; } public string ITEM_CODE { get; set; } = ""; public string ITEM_NAME { get; set; } = ""; public int SORT_ORDER { get; set; } public bool INS_SUBJECT { get; set; } public bool TAX_SUBJECT { get; set; } }
+        private class RunAuditLine : Pay2RunLineDto
+        {
+            public decimal OT_NORMAL_H { get; set; } public decimal OT_HOLIDAY_H { get; set; } public decimal OT_ADMIN_H { get; set; }
+            public decimal LEAVE_DAYS { get; set; } public decimal ABSENT_DAYS { get; set; } public decimal MISSION_DAYS { get; set; }
+            public bool TAX_EXEMPT { get; set; } public decimal REGION_DEPRIVATION { get; set; } public byte INS_TYPE { get; set; }
+            public long PERF_AMOUNT { get; set; } public long TRANSP_AMOUNT { get; set; } public long KASR_OTHER { get; set; }
         }
 
         private static readonly string[] PersianMonthNames =


### PR DESCRIPTION
### Motivation
- Provide a traceable, formula-based Excel export for payroll runs to allow precise comparison between calculated results and the C# engine.
- Replace the previous simple grid exporter with a richer workbook that contains raw data, configuration, a formula sheet and a reconciliation/control sheet.

### Description
- Update `Client/Pages/Salary/Tabs/PayrollTab.razor` to change button label/tooltip and to call `RunApi.GetExcelAuditAsync(CurrentRun.RUN_ID)` and download `Payroll_Audit_{SelectedPeriodDate}_{RUN_ID}.xlsx` instead of the previous local exporter.
- Add `GetExcelAuditAsync` to `Client/Services/Pay2RunApiService.cs` which calls `GET api/pay2/run/{runId}/excel-audit` and returns the byte array with improved error handling.
- Implement `GET api/pay2/run/{runId}/excel-audit` in `Server/Controllers/Pay2RunController.cs` that queries run header, item columns, run lines, details, configuration and tax brackets, then builds a multi-sheet `XLWorkbook` (`تنظیمات`, `داده خام`, `فیش حقوقی`, `کنترل تطابق`) using `ClosedXML` with formula cells to reproduce engine calculations and perform row-level reconciliation.
- Add helper methods and DTOs to the controller: `BuildInsuranceBaseFormula`, `BuildSubjectSumFormula`, `GenerateMonthlyTaxFormula`, `TaxBracketFormulaPart`, `PreviousLimit`, `ColLetter`, and internal classes `RunAuditHead`, `RunAuditColumn`, `RunAuditLine`, and `RunDetailFlat` used by Dapper queries.

### Testing
- Built the solution with `dotnet build` for the `Server` and `Client` projects and the build succeeded.
- Executed available automated tests with `dotnet test` for test projects and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4406baea8c832ea70b10767b5fa69d)