### PR TITLE
Support multi-part account codes and employee detail assignment in GenerateDeed

### DIFF
--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -372,6 +372,55 @@ namespace Safir.Server.Controllers
             catch (Exception ex) { return BadRequest(ex.Message); }
         }
 
+        private sealed class DeedAccount
+        {
+            public int HesK { get; init; }
+            public int HesM { get; init; }
+            public int HesT { get; set; }
+            public int? HesT2 { get; set; }
+            public int? HesT3 { get; set; }
+            public int? HesT4 { get; set; }
+
+            public void ApplyEmployeeDetail(int employeeDetail)
+            {
+                if (HesT == 0)
+                    HesT = employeeDetail;
+                else if (HesT2 is null)
+                    HesT2 = employeeDetail;
+                else if (HesT3 is null)
+                    HesT3 = employeeDetail;
+                else if (HesT4 is null)
+                    HesT4 = employeeDetail;
+                else
+                    throw new InvalidOperationException("کد حسابداری ظرفیت تفصیلی خالی برای اتصال پرسنل ندارد.");
+            }
+        }
+
+        private static DeedAccount ParseDeedAccount(string hesCode, string accKey)
+        {
+            var parts = hesCode.Split('-', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2 || parts.Length > 6)
+                throw new InvalidOperationException($"فرمت کد حسابداری '{hesCode}' برای کلید '{accKey}' نامعتبر است. فرمت مجاز: کل-معین[-تفصیلی[-تفصیلی2[-تفصیلی3[-تفصیلی4]]]].");
+
+            int ParsePart(int index, string label)
+            {
+                if (!int.TryParse(parts[index], out int value))
+                    throw new InvalidOperationException($"بخش {label} در کد حسابداری '{hesCode}' برای کلید '{accKey}' عددی نیست.");
+                return value;
+            }
+
+            return new DeedAccount
+            {
+                HesK = ParsePart(0, "کل"),
+                HesM = ParsePart(1, "معین"),
+                // در دیتابیس‌های مشتری ستون DEED_DTL.HES_T نال‌پذیر نیست؛ برای حساب‌های بدون تفصیلی مقدار صفر ثبت می‌شود.
+                HesT = parts.Length > 2 ? ParsePart(2, "تفصیلی") : 0,
+                HesT2 = parts.Length > 3 ? ParsePart(3, "تفصیلی۲") : null,
+                HesT3 = parts.Length > 4 ? ParsePart(4, "تفصیلی۳") : null,
+                HesT4 = parts.Length > 5 ? ParsePart(5, "تفصیلی۴") : null
+            };
+        }
+
         [HttpPost("{runId:int}/generate-deed")]
         public async Task<IActionResult> GenerateDeed(int runId)
         {
@@ -418,35 +467,42 @@ namespace Safir.Server.Controllers
                     int radif = 1;
                     foreach (var art in articles)
                     {
-                        string hesCode = (string)art.HES_CODE;
-                        var parts = hesCode.Split('-');
+                        string accKey = (string)art.ACC_KEY;
+                        string sharh = (string)art.SHARH;
+                        string? hesCode = art.HES_CODE as string;
 
-                        int hesK = int.Parse(parts[0]);
-                        int hesM = int.Parse(parts[1]);
-                        int? hesT = null;
+                        if (string.IsNullOrWhiteSpace(hesCode))
+                            throw new InvalidOperationException($"کد حسابداری برای آرتیکل '{sharh}' با کلید '{accKey}' تنظیم نشده است. لطفاً سرفصل‌های حسابداری کارگاه را کامل کنید.");
 
-                        // اگر SP پرسنل را مشخص کرده (مثلاً برای مساعده)، کد تفصیلی او را از جدول پرسنل استخراج می‌کنیم
+                        DeedAccount account = ParseDeedAccount(hesCode, accKey);
+
+                        // اگر SP پرسنل را مشخص کرده (مثلاً برای مساعده)، کد تفصیلی او را در اولین سطح تفصیلی خالی می‌گذاریم.
                         if (art.EMP_ID != null)
                         {
                             string? accT = await conn.QuerySingleOrDefaultAsync<string>(
                                 "SELECT ACC_T FROM PAY2_EMPLOYEE WHERE EMP_ID = @empId",
                                 new { empId = (int)art.EMP_ID }, tran);
 
-                            if (!string.IsNullOrWhiteSpace(accT) && int.TryParse(accT, out int tValue))
-                                hesT = tValue;
+                            if (string.IsNullOrWhiteSpace(accT) || !int.TryParse(accT, out int tValue))
+                                throw new InvalidOperationException($"کد تفصیلی حسابداری پرسنل برای آرتیکل '{sharh}' تنظیم نشده یا عددی نیست.");
+
+                            account.ApplyEmployeeDetail(tValue);
                         }
 
                         await conn.ExecuteAsync(@"
-                            INSERT INTO DEED_DTL (N_S, RADIF, HES_K, HES_M, HES_T, SHARH, BED, BES, CRT, UID)
-                            VALUES (@N_S, @RADIF, @HES_K, @HES_M, @HES_T, @SHARH, @BED, @BES, GETDATE(), @UID)",
+                            INSERT INTO DEED_DTL (N_S, RADIF, HES_K, HES_M, HES_T, HES_T2, HES_T3, HES_T4, SHARH, BED, BES, CRT, UID)
+                            VALUES (@N_S, @RADIF, @HES_K, @HES_M, @HES_T, @HES_T2, @HES_T3, @HES_T4, @SHARH, @BED, @BES, GETDATE(), @UID)",
                             new
                             {
                                 N_S = nextNs,
                                 RADIF = radif++,
-                                HES_K = hesK,
-                                HES_M = hesM,
-                                HES_T = hesT,
-                                SHARH = (string)art.SHARH,
+                                HES_K = account.HesK,
+                                HES_M = account.HesM,
+                                HES_T = account.HesT,
+                                HES_T2 = account.HesT2,
+                                HES_T3 = account.HesT3,
+                                HES_T4 = account.HesT4,
+                                SHARH = sharh,
                                 BED = (double)art.BED,
                                 BES = (double)art.BES,
                                 UID = userCod

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -381,6 +381,16 @@ namespace Safir.Server.Controllers
             public int? HesT3 { get; set; }
             public int? HesT4 { get; set; }
 
+            public string Hes => string.Join("-", new[]
+            {
+                HesK,
+                HesM,
+                HesT,
+                HesT2,
+                HesT3,
+                HesT4
+            }.Where(x => x.HasValue).Select(x => x!.Value.ToString()));
+
             public void ApplyEmployeeDetail(int employeeDetail)
             {
                 if (HesT == 0)
@@ -490,8 +500,8 @@ namespace Safir.Server.Controllers
                         }
 
                         await conn.ExecuteAsync(@"
-                            INSERT INTO DEED_DTL (N_S, RADIF, HES_K, HES_M, HES_T, HES_T2, HES_T3, HES_T4, SHARH, BED, BES, CRT, UID)
-                            VALUES (@N_S, @RADIF, @HES_K, @HES_M, @HES_T, @HES_T2, @HES_T3, @HES_T4, @SHARH, @BED, @BES, GETDATE(), @UID)",
+                            INSERT INTO DEED_DTL (N_S, RADIF, HES_K, HES_M, HES_T, HES_T2, HES_T3, HES_T4, SHARH, BED, BES, HES, ARZD, CRT, UID)
+                            VALUES (@N_S, @RADIF, @HES_K, @HES_M, @HES_T, @HES_T2, @HES_T3, @HES_T4, @SHARH, @BED, @BES, @HES, 1, GETDATE(), @UID)",
                             new
                             {
                                 N_S = nextNs,
@@ -502,9 +512,10 @@ namespace Safir.Server.Controllers
                                 HES_T2 = account.HesT2,
                                 HES_T3 = account.HesT3,
                                 HES_T4 = account.HesT4,
+                                HES = account.Hes,
                                 SHARH = sharh,
-                                BED = (double)art.BED,
-                                BES = (double)art.BES,
+                                BED = Convert.ToDouble(art.BED),
+                                BES = Convert.ToDouble(art.BES),
                                 UID = userCod
                             }, tran);
                     }

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -381,15 +381,26 @@ namespace Safir.Server.Controllers
             public int? HesT3 { get; set; }
             public int? HesT4 { get; set; }
 
-            public string Hes => string.Join("-", new[]
+            public string Hes
             {
-                HesK,
-                HesM,
-                HesT,
-                HesT2,
-                HesT3,
-                HesT4
-            }.Where(x => x.HasValue).Select(x => x!.Value.ToString()));
+                get
+                {
+                    var parts = new List<int> { HesK, HesM };
+
+                    // HES_T may be stored as 0 only because some customer databases define it as NOT NULL.
+                    // Do not add that artificial zero to the composite HES string unless a deeper detail exists.
+                    if (HesT != 0 || HesT2 is not null || HesT3 is not null || HesT4 is not null)
+                        parts.Add(HesT);
+                    if (HesT2 is not null)
+                        parts.Add(HesT2.Value);
+                    if (HesT3 is not null)
+                        parts.Add(HesT3.Value);
+                    if (HesT4 is not null)
+                        parts.Add(HesT4.Value);
+
+                    return string.Join("-", parts);
+                }
+            }
 
             public void ApplyEmployeeDetail(int employeeDetail)
             {

--- a/Server/Controllers/Pay2RunController.cs
+++ b/Server/Controllers/Pay2RunController.cs
@@ -419,9 +419,9 @@ namespace Safir.Server.Controllers
 
         private static DeedAccount ParseDeedAccount(string hesCode, string accKey)
         {
-            var parts = hesCode.Split('-', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length < 2 || parts.Length > 6)
-                throw new InvalidOperationException($"فرمت کد حسابداری '{hesCode}' برای کلید '{accKey}' نامعتبر است. فرمت مجاز: کل-معین[-تفصیلی[-تفصیلی2[-تفصیلی3[-تفصیلی4]]]].");
+            var parts = hesCode.Split('-', StringSplitOptions.TrimEntries);
+            if (parts.Length < 2 || parts.Length > 6 || parts.Any(string.IsNullOrWhiteSpace))
+                throw new InvalidOperationException($"فرمت کد حسابداری '{hesCode}' برای کلید '{accKey}' نامعتبر است. فرمت مجاز: کل-معین[-تفصیلی[-تفصیلی2[-تفصیلی3[-تفصیلی4]]]] و هیچ بخش خالی مجاز نیست.");
 
             int ParsePart(int index, string label)
             {


### PR DESCRIPTION
### Motivation

- Support account codes with up to four detail parts (HES_T..HES_T4) when generating accounting entries and correctly map employee-specific detail codes into the first available detail slot.

### Description

- Added a `DeedAccount` helper class and `ParseDeedAccount` to parse `HES` codes into `HES_K`, `HES_M`, `HES_T`, `HES_T2`, `HES_T3`, and `HES_T4` with validation and clear error messages.
- Implemented `ApplyEmployeeDetail` on `DeedAccount` to place an employee detail value into the first empty detail field and throw if no slot is available.
- Updated `GenerateDeed` to use `ACC_KEY` and `SHARH`, validate missing `HES_CODE`, parse multi-part account codes, fetch employee `ACC_T`, apply it via `DeedAccount`, and include `HES_T2`/`HES_T3`/`HES_T4` in the `DEED_DTL` insert.
- Improved validation and error handling to produce actionable errors when account codes or employee detail values are missing or malformed.

### Testing

- Ran the project's automated server test suite with `dotnet test` and the existing integration tests covering the deed generation flow, and they passed.
- Executed the `GenerateDeed` scenario against a local test database to verify multi-part parsing and employee detail assignment, and the flow completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4759228820832eb32db4e11bb50ab5)